### PR TITLE
Read ProjectSettings to pre-populate the logger class list

### DIFF
--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -54,6 +54,19 @@ func _ready() -> void:
 	if settings.show_system_specs:
 		var systemSpecsMsg = LoggieSystemSpecsMsg.new().useLogger(self)
 		systemSpecsMsg.embed_specs().preprocessed(false).info()
+	    
+	if settings.derive_and_show_class_names == true and OS.has_feature("debug"):
+		# Prepopulate class data from ProjectSettings to avoid needing to read files
+		for class_data: Dictionary in ProjectSettings.get_global_class_list():
+			class_names[class_data.path] = class_data.class
+      
+		for autoload_setting: String in ProjectSettings.get_property_list().map(func(prop): return prop.name).filter(func(prop): return prop.begins_with("autoload/") and ProjectSettings.has_setting(prop)):
+			var autoload_class: String = autoload_setting.trim_prefix("autoload/")
+			var class_path: String = ProjectSettings.get_setting(autoload_setting)
+			class_path = class_path.trim_prefix("*")      
+			if not class_names.has(class_path):
+				class_names[class_path] = autoload_class
+
 
 ## Attempts to instantiate a LoggieSettings object from the script at the given [param path].
 ## Returns true if successful, otherwise false and prints an error.


### PR DESCRIPTION
I noticed my Autoloads were being labeled as (Node) and realized in the current system they could never not be (Node) since it's only looking for a class_name in the file. 

After adding autoloads, I found we could read the global_class_list to pre-populate class_names and in most cases, avoid needing FileAccess unless the class is not named at all.