### PR TITLE
V1.2 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ Call one of the output functions (`info`, `notice`, `warn`, `error`, `debug`) at
 ```gdscript
 Loggie.msg("Hello").bold().color(Color.CYAN).info()
 ```
+#### Alternatively
+
+Use Loggie shortcuts if you don't need to apply additional LoggieMsg modifiers.
+
+```gdscript
+Loggie.error("Hello")
+Loggie.info("Hello")
+Loggie.notice("Hello")
+Loggie.warn("Hello")
+Loggie.debug("Hello")
+```
 
 ## BBCode/ANSI Terminal Compatibility
 
@@ -150,7 +161,8 @@ func generate_loot_for(recipient : Creature):
 
 ## Class Name Extraction
 
-A neat feature pulled I from [LogDuck](https://github.com/ZeeWeasel/LogDuck) _(also a cool logging library worth checking out)_, which allows you to see the names of the classes that prompted Loggie to output something.\* This only works when the engine debugger is connected, therefore it does not work in Release mode, and won't be shown in those logs.\*
+A neat feature I saw in [LogDuck](https://github.com/ZeeWeasel/LogDuck) _(also a cool logging library worth checking out)_, which allows you to see the names of the classes that prompted Loggie to output something.
+\* This only works when the engine debugger is connected, therefore it does not work in Release mode, and won't be shown in those logs.\*
 
 ![ClassNameExtraction](https://i.imgur.com/EWlcKnD.png)
 
@@ -186,5 +198,11 @@ I'm looking to improve Loggie over time with more features, flexibility, styling
 # Contributing
 
 All valid improvements and feature contributions are welcome.
+
+Development is done strictly on the `dev` branch marked with the latest (unreleased) version.
+Upon branch completion, that dev branch is merged into `master`, and a new `dev` branch is started for the next version.
+Please make PRs targeted at the latest `dev` branch.
+
 Have a look at [Loggie Development Project](https://github.com/users/Shiva-Shadowsong/projects/2) for a list of identified desired changes.
+
 Feel free to open a PR directly, or if you wish to preemptively discuss your changes or ideas before working on them - talk to me on the [Loggie discord server](https://discord.gg/XPdxpMqmcs).

--- a/addons/loggie/custom_settings.gd.example
+++ b/addons/loggie/custom_settings.gd.example
@@ -16,6 +16,7 @@ func load():
 	self.print_warnings_to_console = true
 	self.use_print_debug_for_debug_msg = true
 	self.derive_and_show_class_names = true
+	self.nameless_class_name_proxy = LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE
 	self.show_timestamps = true
 	self.timestamps_use_utc = true
 
@@ -27,7 +28,7 @@ func load():
 	self.format_info_msg = "%s"
 	self.format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] %s"
 	self.h_separator_symbol = "-"
-	self.box_characters_mode = LoggieTools.BoxCharactersMode.COMPATIBLE
+	self.box_characters_mode = LoggieTools.BoxCharactersMode.COMPATIBLE	
 
 	self.box_symbols_compatible = {
 		"top_left" : "-",

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -56,7 +56,6 @@ func _ready() -> void:
 		var system_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)
 		system_specs_msg.embed_specs().preprocessed(false).info()
 
-
 ## Attempts to instantiate a LoggieSettings object from the script at the given [param path].
 ## Returns true if successful, otherwise false and prints an error.
 func load_settings_from_path(path : String) -> bool:
@@ -102,7 +101,7 @@ func is_domain_enabled(domain_name : String) -> bool:
 ## [method LoggieMsg.info], [method LoggieMsg.warn], etc.
 func msg(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> LoggieMsg:
 	var loggieMsg = LoggieMsg.new(msg, arg1, arg2, arg3, arg4, arg5)
-	loggieMsg.useLogger(self)
+	loggieMsg.use_logger(self)
 	return loggieMsg
 
 ## A shortcut method that instantly creates a [LoggieMsg] with the given arguments and outputs it at the info level.

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -37,7 +37,7 @@ func _ready() -> void:
 			self.settings = _settings.new()
 			self.settings.load()
 			if is_in_production():
-				self.settings.terminal_mode = LoggieTools.TerminalMode.PLAIN
+				self.settings.terminal_mode = LoggieEnums.TerminalMode.PLAIN
 		else:
 			push_error("Loggie loaded neither a custom nor a default settings file. This will break the plugin. Make sure that a valid loggie_settings.gd is in the same directory where loggie.gd is.")
 			return
@@ -49,15 +49,15 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	
-	if settings.show_loggie_specs != LoggieTools.ShowLoggieSpecsMode.DISABLED:
+	if settings.show_loggie_specs != LoggieEnums.ShowLoggieSpecsMode.DISABLED:
 		msg("👀 Loggie {version} booted.".format({"version" : self.VERSION})).color(Color.ORANGE).header().nl().info()
 		var loggie_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)
 		loggie_specs_msg.add(msg("|\t Using Custom Settings File: ").bold(), !uses_original_settings_file).nl().add("|\t ").hseparator(35).nl()
 		
 		match settings.show_loggie_specs:
-			LoggieTools.ShowLoggieSpecsMode.ESSENTIAL:
+			LoggieEnums.ShowLoggieSpecsMode.ESSENTIAL:
 				loggie_specs_msg.embed_essential_logger_specs()
-			LoggieTools.ShowLoggieSpecsMode.ADVANCED:
+			LoggieEnums.ShowLoggieSpecsMode.ADVANCED:
 				loggie_specs_msg.embed_advanced_logger_specs()
 
 		loggie_specs_msg.preprocessed(false).info()

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -52,6 +52,18 @@ func _ready() -> void:
 
 	# Already cache the name of the singleton found at loggie's script path.
 	class_names[self.get_script().resource_path] = LoggieSettings.loggie_singleton_name
+	
+	# Prepopulate class data from ProjectSettings to avoid needing to read files.
+	if settings.derive_and_show_class_names == true and OS.has_feature("debug"):
+		for class_data: Dictionary in ProjectSettings.get_global_class_list():
+			class_names[class_data.path] = class_data.class
+	  
+		for autoload_setting: String in ProjectSettings.get_property_list().map(func(prop): return prop.name).filter(func(prop): return prop.begins_with("autoload/") and ProjectSettings.has_setting(prop)):
+			var autoload_class: String = autoload_setting.trim_prefix("autoload/")
+			var class_path: String = ProjectSettings.get_setting(autoload_setting)
+			class_path = class_path.trim_prefix("*")      
+			if not class_names.has(class_path):
+				class_names[class_path] = autoload_class
 
 	# Don't print Loggie boot messages if Loggie is running only from the editor.
 	if Engine.is_editor_hint():
@@ -73,18 +85,6 @@ func _ready() -> void:
 	if settings.show_system_specs:
 		var system_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)
 		system_specs_msg.embed_specs().preprocessed(false).info()
-	    
-	if settings.derive_and_show_class_names == true and OS.has_feature("debug"):
-		# Prepopulate class data from ProjectSettings to avoid needing to read files
-		for class_data: Dictionary in ProjectSettings.get_global_class_list():
-			class_names[class_data.path] = class_data.class
-      
-		for autoload_setting: String in ProjectSettings.get_property_list().map(func(prop): return prop.name).filter(func(prop): return prop.begins_with("autoload/") and ProjectSettings.has_setting(prop)):
-			var autoload_class: String = autoload_setting.trim_prefix("autoload/")
-			var class_path: String = ProjectSettings.get_setting(autoload_setting)
-			class_path = class_path.trim_prefix("*")      
-			if not class_names.has(class_path):
-				class_names[class_path] = autoload_class
 
 ## Attempts to instantiate a LoggieSettings object from the script at the given [param path].
 ## Returns true if successful, otherwise false and prints an error.

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -54,6 +54,19 @@ func _ready() -> void:
 	if settings.show_system_specs:
 		var systemSpecsMsg = LoggieSystemSpecsMsg.new().useLogger(self)
 		systemSpecsMsg.embed_specs().preprocessed(false).info()
+	    
+	if settings.derive_and_show_class_names == true and OS.has_feature("debug"):
+		# Prepopulate class data from ProjectSettings to avoid needing to read files
+		for class_data: Dictionary in ProjectSettings.get_global_class_list():
+			class_names[class_data.path] = class_data.class
+      
+		for autoload_setting: String in ProjectSettings.get_property_list().map(func(prop): return prop.name).filter(func(prop): return prop.begins_with("autoload/") and ProjectSettings.has_setting(prop)):
+			var autoload_class: String = autoload_setting.trim_prefix("autoload/")
+			var class_path: String = ProjectSettings.get_setting(autoload_setting)
+			class_path = class_path.trim_prefix("*")      
+			if not class_names.has(class_path):
+				class_names[class_path] = autoload_class
+
 
 ## Attempts to instantiate a LoggieSettings object from the script at the given [param path].
 ## Returns true if successful, otherwise false and prints an error.

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -21,9 +21,6 @@ var domains : Dictionary = {}
 var class_names : Dictionary = {}
 
 func _ready() -> void:
-	if Engine.is_editor_hint():
-		return
-
 	var uses_original_settings_file = true
 	var default_settings_path = get_script().get_path().get_base_dir().path_join("loggie_settings.gd")
 	var custom_settings_path = get_script().get_path().get_base_dir().path_join("custom_settings.gd")
@@ -42,6 +39,10 @@ func _ready() -> void:
 		else:
 			push_error("Loggie loaded neither a custom nor a default settings file. This will break the plugin. Make sure that a valid loggie_settings.gd is in the same directory where loggie.gd is.")
 			return
+
+	# Don't print Loggie boot messages if Loggie is running only from the editor.
+	if Engine.is_editor_hint():
+		return
 
 	msg("👀 Loggie {version} booted.".format({"version" : self.VERSION})).color(Color.ORANGE).header().nl().info()
 	

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -47,14 +47,15 @@ func _ready() -> void:
 	msg("👀 Loggie {version} booted.".format({"version" : self.VERSION})).color(Color.ORANGE).header().nl().info()
 	
 	if settings.show_loggie_specs:
-		var loggieSpecsMsg = LoggieSystemSpecsMsg.new().useLogger(self)
-		loggieSpecsMsg.embed_logger_specs()
-		loggieSpecsMsg.add(msg("Using Custom Settings File: ").bold(), !uses_original_settings_file).nl()
-		loggieSpecsMsg.preprocessed(false).info()
+		var loggie_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)
+		loggie_specs_msg.embed_logger_specs()
+		loggie_specs_msg.add(msg("Using Custom Settings File: ").bold(), !uses_original_settings_file).nl()
+		loggie_specs_msg.preprocessed(false).info()
 
 	if settings.show_system_specs:
-		var systemSpecsMsg = LoggieSystemSpecsMsg.new().useLogger(self)
-		systemSpecsMsg.embed_specs().preprocessed(false).info()
+		var system_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)
+		system_specs_msg.embed_specs().preprocessed(false).info()
+
 
 ## Attempts to instantiate a LoggieSettings object from the script at the given [param path].
 ## Returns true if successful, otherwise false and prints an error.

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -6,7 +6,7 @@
 extends Node
 
 ## Stores a string describing the current version of Loggie.
-const VERSION : String = "v1.1"
+const VERSION : String = "v1.2"
 
 ## A reference to the settings of this Loggie. Read more about [LoggieSettings].
 var settings : LoggieSettings

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	var uses_original_settings_file = true
 	var default_settings_path = get_script().get_path().get_base_dir().path_join("loggie_settings.gd")
 	var custom_settings_path = get_script().get_path().get_base_dir().path_join("custom_settings.gd")
-
+	
 	if self.settings == null:
 		if custom_settings_path != null and custom_settings_path != "" and ResourceLoader.exists(custom_settings_path):
 			var loaded_successfully = load_settings_from_path(custom_settings_path)
@@ -40,10 +40,13 @@ func _ready() -> void:
 			push_error("Loggie loaded neither a custom nor a default settings file. This will break the plugin. Make sure that a valid loggie_settings.gd is in the same directory where loggie.gd is.")
 			return
 
+	# Already cache the name of the singleton found at loggie's script path.
+	class_names[self.get_script().resource_path] = LoggieSettings.loggie_singleton_name
+
 	# Don't print Loggie boot messages if Loggie is running only from the editor.
 	if Engine.is_editor_hint():
 		return
-
+	
 	if settings.show_loggie_specs != LoggieTools.ShowLoggieSpecsMode.DISABLED:
 		msg("👀 Loggie {version} booted.".format({"version" : self.VERSION})).color(Color.ORANGE).header().nl().info()
 		var loggie_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -44,12 +44,17 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	msg("👀 Loggie {version} booted.".format({"version" : self.VERSION})).color(Color.ORANGE).header().nl().info()
-	
-	if settings.show_loggie_specs:
+	if settings.show_loggie_specs != LoggieTools.ShowLoggieSpecsMode.DISABLED:
+		msg("👀 Loggie {version} booted.".format({"version" : self.VERSION})).color(Color.ORANGE).header().nl().info()
 		var loggie_specs_msg = LoggieSystemSpecsMsg.new().use_logger(self)
-		loggie_specs_msg.embed_logger_specs()
-		loggie_specs_msg.add(msg("Using Custom Settings File: ").bold(), !uses_original_settings_file).nl()
+		loggie_specs_msg.add(msg("|\t Using Custom Settings File: ").bold(), !uses_original_settings_file).nl().add("|\t ").hseparator(35).nl()
+		
+		match settings.show_loggie_specs:
+			LoggieTools.ShowLoggieSpecsMode.ESSENTIAL:
+				loggie_specs_msg.embed_essential_logger_specs()
+			LoggieTools.ShowLoggieSpecsMode.ADVANCED:
+				loggie_specs_msg.embed_advanced_logger_specs()
+
 		loggie_specs_msg.preprocessed(false).info()
 
 	if settings.show_system_specs:

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -103,3 +103,32 @@ func msg(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = nu
 	loggieMsg.useLogger(self)
 	return loggieMsg
 
+## A shortcut method that instantly creates a [LoggieMsg] with the given arguments and outputs it at the info level.
+## Can be used when you have no intention of customizing a LoggieMsg in any way using helper methods.
+## For customization, use [method msg] instead.
+func info(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> LoggieMsg:
+	return msg(msg, arg1, arg2, arg3, arg4, arg5).info()
+
+## A shortcut method that instantly creates a [LoggieMsg] with the given arguments and outputs it at the warn level.
+## Can be used when you have no intention of customizing a LoggieMsg in any way using helper methods.
+## For customization, use [method msg] instead.
+func warn(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> LoggieMsg:
+	return msg(msg, arg1, arg2, arg3, arg4, arg5).warn()
+
+## A shortcut method that instantly creates a [LoggieMsg] with the given arguments and outputs it at the error level.
+## Can be used when you have no intention of customizing a LoggieMsg in any way using helper methods.
+## For customization, use [method msg] instead.
+func error(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> LoggieMsg:
+	return msg(msg, arg1, arg2, arg3, arg4, arg5).error()
+
+## A shortcut method that instantly creates a [LoggieMsg] with the given arguments and outputs it at the debug level.
+## Can be used when you have no intention of customizing a LoggieMsg in any way using helper methods.
+## For customization, use [method msg] instead.
+func debug(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> LoggieMsg:
+	return msg(msg, arg1, arg2, arg3, arg4, arg5).debug()
+
+## A shortcut method that instantly creates a [LoggieMsg] with the given arguments and outputs it at the notice level.
+## Can be used when you have no intention of customizing a LoggieMsg in any way using helper methods.
+## For customization, use [method msg] instead.
+func notice(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> LoggieMsg:
+	return msg(msg, arg1, arg2, arg3, arg4, arg5).notice()

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -36,6 +36,8 @@ func _ready() -> void:
 		if _settings != null:
 			self.settings = _settings.new()
 			self.settings.load()
+			if is_in_production():
+				self.settings.terminal_mode = LoggieTools.TerminalMode.PLAIN
 		else:
 			push_error("Loggie loaded neither a custom nor a default settings file. This will break the plugin. Make sure that a valid loggie_settings.gd is in the same directory where loggie.gd is.")
 			return

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -8,6 +8,14 @@ extends Node
 ## Stores a string describing the current version of Loggie.
 const VERSION : String = "v1.2"
 
+## Emitted any time Loggie attempts to log a message.
+## Useful for capturing the messages that pass through Loggie.
+## [br][param msg] is the message Loggie attempted to log (before any preprocessing).
+## [br][param preprocessed_content] is what the string content of that message contained after the preprocessing step, 
+## which is what ultimately gets logged.
+## [br][param result] describes the final result of the attempt to log that message.
+signal log_attempted(msg : LoggieMsg, preprocessed_content : String, result : LoggieEnums.LogAttemptResult)
+
 ## A reference to the settings of this Loggie. Read more about [LoggieSettings].
 var settings : LoggieSettings
 

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -74,7 +74,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 
 		# We prepend the name of the class that called the function which resulted in this output being generated
 		# (if Loggie settings are configured to do so).
-		if loggie.settings.derive_and_show_class_names == true:
+		if loggie.settings.derive_and_show_class_names == true and OS.has_feature("debug"):
 			var stack_frame : Dictionary = LoggieTools.get_current_stack_frame_data()
 			var _class_name : String
 

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -82,13 +82,14 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 			if loggie.class_names.has(scriptPath):
 				_class_name = loggie.class_names[scriptPath]
 			else:
-				_class_name = LoggieTools.extract_class_name_from_gd_script(scriptPath)
+				_class_name = LoggieTools.get_class_name_from_script(load(scriptPath), loggie.settings.nameless_class_name_proxy)
 				loggie.class_names[scriptPath] = _class_name
 			
-			msg = "[b]({class_name})[/b] {msg}".format({
-				"class_name" : _class_name,
-				"msg" : msg
-			})
+			if _class_name != "":
+				msg = "[b]({class_name})[/b] {msg}".format({
+					"class_name" : _class_name,
+					"msg" : msg
+				})
 
 		# We prepend a timestamp to the message (if Loggie settings are configured to do so).
 		if loggie.settings.show_timestamps == true:

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -52,7 +52,7 @@ func use_logger(logger_to_use : Variant) -> LoggieMsg:
 ## Outputs the given string [param msg] at the given output level to the standard output using either [method print_rich] or [method print].
 ## It also does a number of changes to the given [param msg] based on various Loggie settings.
 ## Designed to be called internally. You should consider using [method info], [method error], [method warn], [method notice], [method debug] instead.
-func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") -> void:
+func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") -> void:
 	var loggie = get_logger()
 	
 	if loggie == null:
@@ -99,7 +99,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 			})
 
 	match loggie.settings.terminal_mode:
-		LoggieTools.TerminalMode.ANSI:
+		LoggieEnums.TerminalMode.ANSI:
 			# We put the message through the rich_to_ANSI converter which takes care of converting BBCode
 			# to appropriate ANSI. (Only if the TerminalMode is set to ANSI).
 			# Godot claims to be already preparing BBCode output for ANSI, but it only works with a small
@@ -108,9 +108,9 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 			# to support these features instead of having them stripped.
 			msg = LoggieTools.rich_to_ANSI(msg)
 			print_rich(msg)
-		LoggieTools.TerminalMode.BBCODE:
+		LoggieEnums.TerminalMode.BBCODE:
 			print_rich(msg)
-		LoggieTools.TerminalMode.PLAIN, _:
+		LoggieEnums.TerminalMode.PLAIN, _:
 			var plainMsg = LoggieTools.remove_BBCode(msg)
 			print(plainMsg)
 
@@ -119,8 +119,8 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 func error() -> LoggieMsg:
 	var loggie = get_logger()
 	var msg = loggie.settings.format_error_msg % [self.content]
-	output(LoggieTools.LogLevel.ERROR, msg, self.domain_name)
-	if loggie.settings.print_errors_to_console and loggie.settings.log_level >= LoggieTools.LogLevel.ERROR:
+	output(LoggieEnums.LogLevel.ERROR, msg, self.domain_name)
+	if loggie.settings.print_errors_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.ERROR:
 		push_error(self.string())
 	return self
 
@@ -129,8 +129,8 @@ func error() -> LoggieMsg:
 func warn() -> LoggieMsg:
 	var loggie = get_logger()
 	var msg = loggie.settings.format_warning_msg % [self.content]
-	output(LoggieTools.LogLevel.WARN, msg, self.domain_name)
-	if loggie.settings.print_warnings_to_console and loggie.settings.log_level >= LoggieTools.LogLevel.WARN:
+	output(LoggieEnums.LogLevel.WARN, msg, self.domain_name)
+	if loggie.settings.print_warnings_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.WARN:
 		push_warning(self.string())
 	return self
 
@@ -139,7 +139,7 @@ func warn() -> LoggieMsg:
 func notice() -> LoggieMsg:
 	var loggie = get_logger()
 	var msg = loggie.settings.format_notice_msg % [self.content]
-	output(LoggieTools.LogLevel.NOTICE, msg, self.domain_name)
+	output(LoggieEnums.LogLevel.NOTICE, msg, self.domain_name)
 	return self
 
 ## Outputs this message from Loggie as an Info type message.
@@ -147,7 +147,7 @@ func notice() -> LoggieMsg:
 func info() -> LoggieMsg:
 	var loggie = get_logger()
 	var msg = loggie.settings.format_info_msg % [self.content]
-	output(LoggieTools.LogLevel.INFO, msg, self.domain_name)
+	output(LoggieEnums.LogLevel.INFO, msg, self.domain_name)
 	return self
 
 ## Outputs this message from Loggie as a Debug type message.
@@ -155,8 +155,8 @@ func info() -> LoggieMsg:
 func debug() -> LoggieMsg:
 	var loggie = get_logger()
 	var msg = loggie.settings.format_debug_msg % [self.content]
-	output(LoggieTools.LogLevel.DEBUG, msg, self.domain_name)
-	if loggie.settings.use_print_debug_for_debug_msg and loggie.settings.log_level >= LoggieTools.LogLevel.DEBUG:
+	output(LoggieEnums.LogLevel.DEBUG, msg, self.domain_name)
+	if loggie.settings.use_print_debug_for_debug_msg and loggie.settings.log_level >= LoggieEnums.LogLevel.DEBUG:
 		print_debug(self.string())
 	return self
 
@@ -216,7 +216,7 @@ func box(h_padding : int = 4):
 	var stripped_content = LoggieTools.remove_BBCode(self.content).strip_edges(true, true)
 	var content_length = stripped_content.length()
 	var h_fill_length = content_length + (h_padding * 2)
-	var box_character_source = loggie.settings.box_symbols_compatible if loggie.settings.box_characters_mode == LoggieTools.BoxCharactersMode.COMPATIBLE else loggie.settings.box_symbols_pretty
+	var box_character_source = loggie.settings.box_symbols_compatible if loggie.settings.box_characters_mode == LoggieEnums.BoxCharactersMode.COMPATIBLE else loggie.settings.box_symbols_pretty
 
 	var top_row_design = "{top_left_corner}{h_fill}{top_right_corner}".format({
 		"top_left_corner" : box_character_source.top_left,

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -32,7 +32,7 @@ var domain_name : String = ""
 var preprocess : bool = true
 
 ## Stores a reference to the logger that generated this message, from which we need to read settings and other data.
-## This variable should be set with [method useLogger] before an attempt is made to log this message out.
+## This variable should be set with [method use_logger] before an attempt is made to log this message out.
 var _logger : Variant
 
 func _init(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> void:
@@ -40,12 +40,12 @@ func _init(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = 
 	self.original_content = self.content
 
 ## Returns a reference to the logger object that created this message.
-func getLogger() -> Variant:
+func get_logger() -> Variant:
 	return self._logger
 
 ## Sets this message to use the given [param logger] as the logger from which it will be reading
 ## settings. The given logger should be of class [Loggie] or an extension of it.
-func useLogger(logger_to_use : Variant) -> LoggieMsg:
+func use_logger(logger_to_use : Variant) -> LoggieMsg:
 	self._logger = logger_to_use
 	return self
 
@@ -53,10 +53,10 @@ func useLogger(logger_to_use : Variant) -> LoggieMsg:
 ## It also does a number of changes to the given [param msg] based on various Loggie settings.
 ## Designed to be called internally. You should consider using [method info], [method error], [method warn], [method notice], [method debug] instead.
 func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") -> void:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	
 	if loggie == null:
-		push_error("Attempt to log output with an invalid _logger. Make sure to call LoggieMsg.useLogger to set the appropriate logger before working with the message.")
+		push_error("Attempt to log output with an invalid _logger. Make sure to call LoggieMsg.use_logger to set the appropriate logger before working with the message.")
 		return
 
 	# We don't output the message if the settings dictate that messages of that level shouldn't be outputted.
@@ -118,7 +118,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 ## Outputs this message from Loggie as an Error type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the ERROR level for this to work.
 func error() -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var msg = loggie.settings.format_error_msg % [self.content]
 	output(LoggieTools.LogLevel.ERROR, msg, self.domain_name)
 	if loggie.settings.print_errors_to_console and loggie.settings.log_level >= LoggieTools.LogLevel.ERROR:
@@ -128,7 +128,7 @@ func error() -> LoggieMsg:
 ## Outputs this message from Loggie as an Warning type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the WARN level for this to work.
 func warn() -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var msg = loggie.settings.format_warning_msg % [self.content]
 	output(LoggieTools.LogLevel.WARN, msg, self.domain_name)
 	if loggie.settings.print_warnings_to_console and loggie.settings.log_level >= LoggieTools.LogLevel.WARN:
@@ -138,7 +138,7 @@ func warn() -> LoggieMsg:
 ## Outputs this message from Loggie as an Notice type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the NOTICE level for this to work.
 func notice() -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var msg = loggie.settings.format_notice_msg % [self.content]
 	output(LoggieTools.LogLevel.NOTICE, msg, self.domain_name)
 	return self
@@ -146,7 +146,7 @@ func notice() -> LoggieMsg:
 ## Outputs this message from Loggie as an Info type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the INFO level for this to work.
 func info() -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var msg = loggie.settings.format_info_msg % [self.content]
 	output(LoggieTools.LogLevel.INFO, msg, self.domain_name)
 	return self
@@ -154,7 +154,7 @@ func info() -> LoggieMsg:
 ## Outputs this message from Loggie as a Debug type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the DEBUG level for this to work.
 func debug() -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var msg = loggie.settings.format_debug_msg % [self.content]
 	output(LoggieTools.LogLevel.DEBUG, msg, self.domain_name)
 	if loggie.settings.use_print_debug_for_debug_msg and loggie.settings.log_level >= LoggieTools.LogLevel.DEBUG:
@@ -205,7 +205,7 @@ func italic() -> LoggieMsg:
 
 ## Stylizes the current content of this message as a header.
 func header() -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	self.content = loggie.settings.format_header % self.content
 	return self
 
@@ -213,7 +213,7 @@ func header() -> LoggieMsg:
 ## of this message. Messages containing a box are not going to be preprocessed, so they are best
 ## used only as a special header or decoration.
 func box(h_padding : int = 4):
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var stripped_content = LoggieTools.remove_BBCode(self.content).strip_edges(true, true)
 	var content_length = stripped_content.length()
 	var h_fill_length = content_length + (h_padding * 2)
@@ -290,7 +290,7 @@ func suffix(suffix : String, separator : String = "") -> LoggieMsg:
 ## Appends a horizontal separator with the given length to the message.
 ## If [param alternative_symbol] is provided, it should be a String, and it will be used as the symbol for the separator instead of the default one.
 func hseparator(size : int = 16, alternative_symbol : Variant = null) -> LoggieMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var symbol = loggie.settings.h_separator_symbol if alternative_symbol == null else str(alternative_symbol)
 	self.content += (symbol.repeat(size))
 	return self

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -61,10 +61,12 @@ func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") ->
 
 	# We don't output the message if the settings dictate that messages of that level shouldn't be outputted.
 	if level > loggie.settings.log_level:
+		loggie.log_attempted.emit(self, msg, LoggieEnums.LogAttemptResult.LOG_LEVEL_INSUFFICIENT)
 		return
 
 	# We don't output the message if the domain from which it comes is not enabled.
 	if not loggie.is_domain_enabled(domain):
+		loggie.log_attempted.emit(self, msg, LoggieEnums.LogAttemptResult.DOMAIN_DISABLED)
 		return
 
 	if self.preprocess:
@@ -111,8 +113,10 @@ func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") ->
 		LoggieEnums.TerminalMode.BBCODE:
 			print_rich(msg)
 		LoggieEnums.TerminalMode.PLAIN, _:
-			var plainMsg = LoggieTools.remove_BBCode(msg)
-			print(plainMsg)
+			msg = LoggieTools.remove_BBCode(msg)
+			print(msg)
+			
+	loggie.log_attempted.emit(self, msg, LoggieEnums.LogAttemptResult.SUCCESS)
 
 ## Outputs this message from Loggie as an Error type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the ERROR level for this to work.

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -32,6 +32,7 @@ var domain_name : String = ""
 var preprocess : bool = true
 
 ## Stores a reference to the logger that generated this message, from which we need to read settings and other data.
+## This variable should be set with [method useLogger] before an attempt is made to log this message out.
 var _logger : Variant
 
 func _init(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> void:
@@ -39,8 +40,6 @@ func _init(msg = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = 
 	self.original_content = self.content
 
 ## Returns a reference to the logger object that created this message.
-## If the currently stored reference is null, an attempt will be made to automatically obtain the reference
-## for an autoloaded singleton named 'Loggie'.
 func getLogger() -> Variant:
 	return self._logger
 
@@ -101,7 +100,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 	var usedTerminalMode = LoggieTools.TerminalMode.PLAIN if loggie.is_in_production() else loggie.settings.terminal_mode
 	match usedTerminalMode:
 		LoggieTools.TerminalMode.ANSI:
-			# We put the message through the rich_to_ANSI converted which takes care of converting BBCode
+			# We put the message through the rich_to_ANSI converter which takes care of converting BBCode
 			# to appropriate ANSI. (Only if the TerminalMode is set to ANSI).
 			# Godot claims to be already preparing BBCode output for ANSI, but it only works with a small
 			# predefined set of colors, and I think it totally strips stuff like [b], [i], etc.

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -74,7 +74,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 
 		# We prepend the name of the class that called the function which resulted in this output being generated
 		# (if Loggie settings are configured to do so).
-		if loggie.settings.derive_and_show_class_names == true and OS.has_feature("debug"):
+		if loggie.settings.derive_and_show_class_names == true:
 			var stack_frame : Dictionary = LoggieTools.get_current_stack_frame_data()
 			var _class_name : String
 
@@ -82,7 +82,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 			if loggie.class_names.has(scriptPath):
 				_class_name = loggie.class_names[scriptPath]
 			else:
-				_class_name = LoggieTools.get_class_name_from_script(load(scriptPath), loggie.settings.nameless_class_name_proxy)
+				_class_name = LoggieTools.get_class_name_from_script(scriptPath, loggie.settings.nameless_class_name_proxy)
 				loggie.class_names[scriptPath] = _class_name
 			
 			if _class_name != "":
@@ -98,8 +98,7 @@ func output(level : LoggieTools.LogLevel, msg : String, domain : String = "") ->
 				"msg" : msg
 			})
 
-	var usedTerminalMode = LoggieTools.TerminalMode.PLAIN if loggie.is_in_production() else loggie.settings.terminal_mode
-	match usedTerminalMode:
+	match loggie.settings.terminal_mode:
 		LoggieTools.TerminalMode.ANSI:
 			# We put the message through the rich_to_ANSI converter which takes care of converting BBCode
 			# to appropriate ANSI. (Only if the TerminalMode is set to ANSI).

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -46,11 +46,11 @@ const project_settings = {
 	},
 	"show_loggie_specs" = {
 		"path": "loggie/general/show_loggie_specs",
-		"default_value" : true,
-		"type" : TYPE_BOOL,
-		"hint" : PROPERTY_HINT_NONE,
-		"hint_string" : "",
-		"doc" : "Should Loggie log its own specs when it is booted?",
+		"default_value" : LoggieTools.ShowLoggieSpecsMode.ESSENTIAL,
+		"type" : TYPE_INT,
+		"hint" : PROPERTY_HINT_ENUM,
+		"hint_string" : "Disabled:0,Essential:1,Advanced:2",
+		"doc" : "Defines which way Loggie should print its own specs when it is booted.",
 	},
 	"output_timestamps" = {
 		"path": "loggie/timestamps/output_timestamps",
@@ -140,7 +140,7 @@ var terminal_mode : LoggieTools.TerminalMode
 var log_level : LoggieTools.LogLevel
 
 ## Whether or not Loggie should log the loggie specs on ready.
-var show_loggie_specs : bool
+var show_loggie_specs : LoggieTools.ShowLoggieSpecsMode
 
 ## Whether or not Loggie should log the system specs on ready.
 var show_system_specs : bool

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -261,3 +261,19 @@ func load():
 	derive_and_show_class_names = ProjectSettings.get_setting(project_settings.derive_and_display_class_names_from_scripts.path, project_settings.derive_and_display_class_names_from_scripts.default_value)
 	nameless_class_name_proxy = ProjectSettings.get_setting(project_settings.nameless_class_name_proxy.path, project_settings.nameless_class_name_proxy.default_value)
 	box_characters_mode = ProjectSettings.get_setting(project_settings.box_characters_mode.path, project_settings.box_characters_mode.default_value)
+
+## Returns a dictionary where the indices are names of relevant variables in the LoggieSettings class,
+## and the values are their current values.
+func to_dict() -> Dictionary:
+	var dict = {}
+	var included = [
+		"terminal_mode", "log_level", "show_loggie_specs", "show_system_specs",
+		"output_message_domain", "print_errors_to_console", "print_warnings_to_console",
+		"use_print_debug_for_debug_msg", "derive_and_show_class_names", "nameless_class_name_proxy",
+		"show_timestamps", "timestamps_use_utc", "format_header", "format_domain_prefix", "format_error_msg",
+		"format_warning_msg", "format_notice_msg", "format_info_msg", "format_debug_msg",
+		"h_separator_symbol", "box_characters_mode", "box_symbols_compatible", "box_symbols_pretty",
+	]
+	for var_name in included:
+		dict[var_name] = Loggie.settings.get(var_name)
+	return dict

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -100,6 +100,14 @@ const project_settings = {
 		"hint_string" : "",
 		"doc" : "If true, Loggie will attempt to find out the name of the main class from which the log line is coming and append it in front of the message.",
 	},
+	"nameless_class_name_proxy" = {
+		"path": "loggie/preprocessing/nameless_class_name_proxy",
+		"default_value" : LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE,
+		"type" : TYPE_INT,
+		"hint" : PROPERTY_HINT_ENUM,
+		"hint_string" : "Nothing:0,ScriptName:1,BaseType:2",
+		"doc" : "If 'Derive and Display Class Names From Scripts' is enabled, and a script doesn't have a 'class_name', which text should we use as a substitute?",
+	},
 	"output_message_domain" = {
 		"path": "loggie/preprocessing/output_message_domain",
 		"default_value" : false,
@@ -158,13 +166,17 @@ var use_print_debug_for_debug_msg : bool
 ## and display it at the start of each output message.
 ## This only works in debug builds because it uses [method @GDScript.get_stack]. 
 ## See that method's documentation to see why that can't be used in release builds.
-var derive_and_show_class_names
+var derive_and_show_class_names : bool
+
+## Defines which text will be used as a substitute for the 'class_name' of scripts that do not have a 'class_name'.
+## Relevant only if [member derive_and_show_class_names] is enabled.
+var nameless_class_name_proxy : LoggieTools.NamelessClassExtensionNameProxy
 
 ## Whether Loggie should prepend a timestamp to each output message.
-var show_timestamps
+var show_timestamps : bool
 
 ## Whether the outputted timestamps (if [member show_timestamps] is enabled) use UTC or local machine time.
-var timestamps_use_utc
+var timestamps_use_utc : bool
 
 # ----------------------------------------------- #
 #region Formats for prints
@@ -247,4 +259,5 @@ func load():
 
 	output_message_domain = ProjectSettings.get_setting(project_settings.output_message_domain.path, project_settings.output_message_domain.default_value)
 	derive_and_show_class_names = ProjectSettings.get_setting(project_settings.derive_and_display_class_names_from_scripts.path, project_settings.derive_and_display_class_names_from_scripts.default_value)
+	nameless_class_name_proxy = ProjectSettings.get_setting(project_settings.nameless_class_name_proxy.path, project_settings.nameless_class_name_proxy.default_value)
 	box_characters_mode = ProjectSettings.get_setting(project_settings.box_characters_mode.path, project_settings.box_characters_mode.default_value)

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -22,7 +22,7 @@ static var loggie_singleton_name = "Loggie"
 const project_settings = {
 	"terminal_mode" = {
 		"path": "loggie/general/terminal_mode",
-		"default_value" : LoggieTools.TerminalMode.BBCODE,
+		"default_value" : LoggieEnums.TerminalMode.BBCODE,
 		"type" : TYPE_INT,
 		"hint" : PROPERTY_HINT_ENUM,
 		"hint_string" : "Plain:0,ANSI:1,BBCode:2",
@@ -30,7 +30,7 @@ const project_settings = {
 	},
 	"log_level" = {
 		"path": "loggie/general/log_level",
-		"default_value" : LoggieTools.LogLevel.INFO,
+		"default_value" : LoggieEnums.LogLevel.INFO,
 		"type" : TYPE_INT,
 		"hint" : PROPERTY_HINT_ENUM,
 		"hint_string" : "Error:0,Warn:1,Notice:2,Info:3,Debug:4",
@@ -46,7 +46,7 @@ const project_settings = {
 	},
 	"show_loggie_specs" = {
 		"path": "loggie/general/show_loggie_specs",
-		"default_value" : LoggieTools.ShowLoggieSpecsMode.ESSENTIAL,
+		"default_value" : LoggieEnums.ShowLoggieSpecsMode.ESSENTIAL,
 		"type" : TYPE_INT,
 		"hint" : PROPERTY_HINT_ENUM,
 		"hint_string" : "Disabled:0,Essential:1,Advanced:2",
@@ -102,7 +102,7 @@ const project_settings = {
 	},
 	"nameless_class_name_proxy" = {
 		"path": "loggie/preprocessing/nameless_class_name_proxy",
-		"default_value" : LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE,
+		"default_value" : LoggieEnums.NamelessClassExtensionNameProxy.BASE_TYPE,
 		"type" : TYPE_INT,
 		"hint" : PROPERTY_HINT_ENUM,
 		"hint_string" : "Nothing:0,ScriptName:1,BaseType:2",
@@ -118,7 +118,7 @@ const project_settings = {
 	},
 	"box_characters_mode" = {
 		"path": "loggie/preprocessing/box_characters_mode",
-		"default_value" : LoggieTools.BoxCharactersMode.COMPATIBLE,
+		"default_value" : LoggieEnums.BoxCharactersMode.COMPATIBLE,
 		"type" : TYPE_INT,
 		"hint" : PROPERTY_HINT_ENUM,
 		"hint_string" : "Compatible:0,Pretty:1",
@@ -132,15 +132,15 @@ const project_settings = {
 ## [br][br]BBCode is compatible with the Godot console.
 ## [br]ANSI is compatible with consoles like Powershell and Windows CMD.
 ## [br]PLAIN is used to strip any effects and use plain text instead, which is good for saving raw logs into log files.
-var terminal_mode : LoggieTools.TerminalMode
+var terminal_mode : LoggieEnums.TerminalMode
 
 ## The current log level of Loggie.
 ## It determines which types of messages are allowed to be logged.
 ## Set this using [method setLogLevel].
-var log_level : LoggieTools.LogLevel
+var log_level : LoggieEnums.LogLevel
 
 ## Whether or not Loggie should log the loggie specs on ready.
-var show_loggie_specs : LoggieTools.ShowLoggieSpecsMode
+var show_loggie_specs : LoggieEnums.ShowLoggieSpecsMode
 
 ## Whether or not Loggie should log the system specs on ready.
 var show_system_specs : bool
@@ -170,7 +170,7 @@ var derive_and_show_class_names : bool
 
 ## Defines which text will be used as a substitute for the 'class_name' of scripts that do not have a 'class_name'.
 ## Relevant only if [member derive_and_show_class_names] is enabled.
-var nameless_class_name_proxy : LoggieTools.NamelessClassExtensionNameProxy
+var nameless_class_name_proxy : LoggieEnums.NamelessClassExtensionNameProxy
 
 ## Whether Loggie should prepend a timestamp to each output message.
 var show_timestamps : bool
@@ -210,7 +210,7 @@ var format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] %s"
 var h_separator_symbol = "-"
 
 ## The mode used for drawing boxes.
-var box_characters_mode : LoggieTools.BoxCharactersMode
+var box_characters_mode : LoggieEnums.BoxCharactersMode
 
 ## The symbols which will be used to construct a box decoration that will properly
 ## display on any kind of terminal or text reader.

--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -4,12 +4,10 @@ class_name LoggieEditorPlugin extends EditorPlugin
 func _enter_tree():
 	add_autoload_singleton(LoggieSettings.loggie_singleton_name, "res://addons/loggie/loggie.gd")
 	add_loggie_project_settings()
-	print("Loggie entered tree")
 
-func _exit_tree() -> void:
-	remove_loggie_project_setings()
+func _disable_plugin() -> void:
 	remove_autoload_singleton(LoggieSettings.loggie_singleton_name)
-	print("Loggie exited tree")
+	remove_loggie_project_setings()
 
 ## Adds new Loggie related ProjectSettings to Godot.
 func add_loggie_project_settings():

--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -4,10 +4,12 @@ class_name LoggieEditorPlugin extends EditorPlugin
 func _enter_tree():
 	add_autoload_singleton(LoggieSettings.loggie_singleton_name, "res://addons/loggie/loggie.gd")
 	add_loggie_project_settings()
+	print("Loggie entered tree")
 
 func _exit_tree() -> void:
 	remove_loggie_project_setings()
 	remove_autoload_singleton(LoggieSettings.loggie_singleton_name)
+	print("Loggie exited tree")
 
 ## Adds new Loggie related ProjectSettings to Godot.
 func add_loggie_project_settings():

--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -4,10 +4,13 @@ class_name LoggieEditorPlugin extends EditorPlugin
 func _enter_tree():
 	add_autoload_singleton(LoggieSettings.loggie_singleton_name, "res://addons/loggie/loggie.gd")
 	add_loggie_project_settings()
+	
+func _enable_plugin() -> void:
+	add_loggie_project_settings()
 
 func _disable_plugin() -> void:
-	remove_autoload_singleton(LoggieSettings.loggie_singleton_name)
 	remove_loggie_project_setings()
+	remove_autoload_singleton(LoggieSettings.loggie_singleton_name)
 
 ## Adds new Loggie related ProjectSettings to Godot.
 func add_loggie_project_settings():
@@ -27,10 +30,10 @@ func remove_loggie_project_setings():
 ## TODO: Figure out how to also add the documentation to the ProjectSetting so that it shows up 
 ## in the Godot Editor tooltip when the setting is hovered over.
 func add_project_setting(setting_name: String, default_value : Variant, value_type: int, type_hint: int = PROPERTY_HINT_NONE, hint_string: String = "", documentation : String = ""):
-	if ProjectSettings.has_setting(setting_name): 
-		return
-
-	ProjectSettings.set_setting(setting_name, default_value)
+	if !ProjectSettings.has_setting(setting_name):
+		ProjectSettings.set_setting(setting_name, default_value)
+		
+	ProjectSettings.set_initial_value(setting_name, default_value)
 	
 	ProjectSettings.add_property_info({
 		"name": setting_name,
@@ -39,8 +42,6 @@ func add_project_setting(setting_name: String, default_value : Variant, value_ty
 		"hint_string": hint_string
 	})
 
-	ProjectSettings.set_initial_value(setting_name, default_value)
-	
 	var error: int = ProjectSettings.save()
 	if error: 
 		push_error("Loggie - Encountered error %d while saving project settings." % error)

--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -22,7 +22,7 @@ func remove_loggie_project_setings():
 		ProjectSettings.set_setting(setting["path"], null)
 	
 	var error: int = ProjectSettings.save()
-	if error: 
+	if error != OK: 
 		push_error("Loggie - Encountered error %d while saving project settings." % error)
 
 ## Adds a new project setting to Godot.

--- a/addons/loggie/tools/loggie_enums.gd
+++ b/addons/loggie/tools/loggie_enums.gd
@@ -35,3 +35,10 @@ enum ShowLoggieSpecsMode {
 	ESSENTIAL, ## Show only the essentials.
 	ADVANCED ## Show all loggie specs.
 }
+
+## Defines a list of possible outcomes that can happen when attempting to log a message.
+enum LogAttemptResult {
+	SUCCESS, ## Message will be logged successfully.
+	LOG_LEVEL_INSUFFICIENT, ## Message won't be logged because it was output at a log level higher than what Loggie is currently set to.
+	DOMAIN_DISABLED, ## Message won't be logged because it was outputted from a disabled domain.
+}

--- a/addons/loggie/tools/loggie_enums.gd
+++ b/addons/loggie/tools/loggie_enums.gd
@@ -1,0 +1,37 @@
+@tool
+class_name LoggieEnums extends Node
+
+## Based on which log level is currently set to be used by the Loggie., attempting to log a message that's on
+## a higher-than-configured log level will result in nothing happening.
+enum LogLevel {
+	ERROR, 	## Log level which includes only the logging of Error type messages.
+	WARN, 	## Log level which includes the logging of Error and Warning type messages.
+	NOTICE, ## Log level which includes the logging of Error, Warning and Notice type messages.
+	INFO,	## Log level which includes the logging of Error, Warning, Notice and Info type messages.
+	DEBUG	## Log level which includes the logging of Error, Warning, Notice, Info and Debug type messages.
+}
+
+enum TerminalMode {
+	PLAIN, ## Prints will be plain text.
+	ANSI,  ## Prints will be styled using the ANSI standard. Compatible with Powershell, Win CMD, etc.
+	BBCODE ## Prints will be styled using the Godot BBCode rules. Compatible with the Godot console.
+}
+
+enum BoxCharactersMode {
+	COMPATIBLE, ## Boxes are drawn using characters that compatible with any kind of terminal or text reader.
+	PRETTY ## Boxes are drawn using special unicode characters that create a prettier looking box which may not display properly in some terminals or text readers.
+}
+
+## Defines a list of possible approaches that can be taken to derive some kind of a class name proxy from a script that doesn't have a 'class_name' clause.
+enum NamelessClassExtensionNameProxy {
+	NOTHING, ## If there is no class_name, nothing will be displayed.
+	SCRIPT_NAME, ## Use the name of the script whose class_name we tried to read. (e.g. "my_script.gd").
+	BASE_TYPE, ## Use the name of the base type which the script extends (e.g. 'Node2D', 'Control', etc.)
+}
+
+## Defines a list of possible behaviors for the 'show_loggie_specs' setting.
+enum ShowLoggieSpecsMode {
+	DISABLED, ## Loggie specs won't be shown.
+	ESSENTIAL, ## Show only the essentials.
+	ADVANCED ## Show all loggie specs.
+}

--- a/addons/loggie/tools/loggie_system_specs.gd
+++ b/addons/loggie/tools/loggie_system_specs.gd
@@ -17,13 +17,35 @@ func embed_specs() -> LoggieSystemSpecsMsg:
 	self.embed_input_specs()
 	return self
 
-## Embeds data about the logger into the content of this message.
-func embed_logger_specs() -> LoggieSystemSpecsMsg:
+## Embeds essential data about the logger into the content of this message.
+func embed_essential_logger_specs() -> LoggieSystemSpecsMsg:
 	var loggie = get_logger()
-	self.add(loggie.msg("Terminal Mode:").bold(), LoggieTools.TerminalMode.keys()[loggie.settings.terminal_mode]).suffix(" - ")
-	self.add(loggie.msg("Log Level:").bold(), LoggieTools.LogLevel.keys()[loggie.settings.log_level]).suffix(" - ")
-	self.add(loggie.msg("Is in Production:").bold(), loggie.is_in_production()).suffix(" - ")
-	self.add(loggie.msg("Box Characters Mode:").bold(), LoggieTools.BoxCharactersMode.keys()[loggie.settings.box_characters_mode]).nl()
+	self.add(loggie.msg("|\t Is in Production:").bold(), loggie.is_in_production()).nl()
+	self.add(loggie.msg("|\t Terminal Mode:").bold(), LoggieTools.TerminalMode.keys()[loggie.settings.terminal_mode]).nl()
+	self.add(loggie.msg("|\t Log Level:").bold(), LoggieTools.LogLevel.keys()[loggie.settings.log_level]).nl()
+	return self
+
+## Embeds advanced data about the logger into the content of this message.
+func embed_advanced_logger_specs() -> LoggieSystemSpecsMsg:
+	var loggie = get_logger()
+	
+	self.add(loggie.msg("|\t Is in Production:").bold(), loggie.is_in_production()).nl()
+	
+	var settings_dict = loggie.settings.to_dict()
+	for setting_var_name : String in settings_dict.keys():
+		var setting_value = settings_dict[setting_var_name]
+		var content_to_print = setting_value
+		
+		match setting_var_name:
+			"terminal_mode":
+				content_to_print = LoggieTools.TerminalMode.keys()[setting_value]
+			"log_level":
+				content_to_print = LoggieTools.LogLevel.keys()[setting_value]
+			"box_characters_mode":
+				content_to_print = LoggieTools.BoxCharactersMode.keys()[setting_value]
+
+		self.add(loggie.msg("|\t", setting_var_name.capitalize(), ":").bold(), content_to_print).nl()
+	
 	return self
 
 ## Adds data about the user's software to the content of this message.

--- a/addons/loggie/tools/loggie_system_specs.gd
+++ b/addons/loggie/tools/loggie_system_specs.gd
@@ -19,7 +19,7 @@ func embed_specs() -> LoggieSystemSpecsMsg:
 
 ## Embeds data about the logger into the content of this message.
 func embed_logger_specs() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	self.add(loggie.msg("Terminal Mode:").bold(), LoggieTools.TerminalMode.keys()[loggie.settings.terminal_mode]).suffix(" - ")
 	self.add(loggie.msg("Log Level:").bold(), LoggieTools.LogLevel.keys()[loggie.settings.log_level]).suffix(" - ")
 	self.add(loggie.msg("Is in Production:").bold(), loggie.is_in_production()).suffix(" - ")
@@ -28,21 +28,21 @@ func embed_logger_specs() -> LoggieSystemSpecsMsg:
 
 ## Adds data about the user's software to the content of this message.
 func embed_system_specs() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var header = loggie.msg("Operating System: ").color(Color.ORANGE).add(OS.get_name()).box(4)
 	self.add(header)
 	return self
 	
 ## Adds data about localization to the content of this message.
 func embed_localization_specs() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var header = loggie.msg("Localization: ").color(Color.ORANGE).add(OS.get_locale()).box(7)
 	self.add(header)
 	return self
 
 ## Adds data about the current date/time to the content of this message.
 func embed_date_data() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var header = loggie.msg("Date").color(Color.ORANGE).box(15)
 	self.add(header)
 	self.add(loggie.msg("Date and time (local):").bold(), Time.get_datetime_string_from_system(false, true)).nl()
@@ -57,7 +57,7 @@ func embed_date_data() -> LoggieSystemSpecsMsg:
 
 ## Adds data about the user's hardware to the content of this message.
 func embed_hardware_specs() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var header = loggie.msg("Hardware").color(Color.ORANGE).box(13)
 	self.add(header)
 	self.add(loggie.msg("Model name:").bold(), OS.get_model_name()).nl()
@@ -69,7 +69,7 @@ func embed_video_specs() -> LoggieSystemSpecsMsg:
 	const adapter_type_to_string = ["Other (Unknown)", "Integrated", "Discrete", "Virtual", "CPU"]
 	var adapter_type_string = adapter_type_to_string[RenderingServer.get_video_adapter_type()]
 	var video_adapter_driver_info = OS.get_video_adapter_driver_info()
-	var loggie = getLogger()
+	var loggie = get_logger()
 
 	var header = loggie.msg("Video").color(Color.ORANGE).box(15)
 	self.add(header)
@@ -97,7 +97,7 @@ func embed_display_specs() -> LoggieSystemSpecsMsg:
 		"Defined by sensor",
 	]
 	var screen_orientation_string = screen_orientation_to_string[DisplayServer.screen_get_orientation()]
-	var loggie = getLogger()
+	var loggie = get_logger()
 
 	var header = loggie.msg("Display").color(Color.ORANGE).box(13)
 	self.add(header)
@@ -114,7 +114,7 @@ func embed_display_specs() -> LoggieSystemSpecsMsg:
 
 ## Adds data about the audio system to the content of this message.
 func embed_audio_specs() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var header = loggie.msg("Audio").color(Color.ORANGE).box(14)
 	self.add(header)
 	self.add(loggie.msg("Mix rate:").bold(), "%d Hz" % AudioServer.get_mix_rate()).nl()
@@ -125,7 +125,7 @@ func embed_audio_specs() -> LoggieSystemSpecsMsg:
 
 ## Adds data about the godot engine to the content of this message.
 func embed_engine_specs() -> LoggieSystemSpecsMsg:
-	var loggie = getLogger()
+	var loggie = get_logger()
 	var header = loggie.msg("Engine").color(Color.ORANGE).box(14)
 	self.add(header)
 	self.add(loggie.msg("Version:").bold(), Engine.get_version_info()["string"]).nl()
@@ -137,7 +137,7 @@ func embed_engine_specs() -> LoggieSystemSpecsMsg:
 ## Adds data about the input device to the content of this message.
 func embed_input_specs() -> LoggieSystemSpecsMsg:
 	var has_virtual_keyboard = DisplayServer.has_feature(DisplayServer.FEATURE_VIRTUAL_KEYBOARD)
-	var loggie = getLogger()
+	var loggie = get_logger()
 
 	var header = loggie.msg("Input").color(Color.ORANGE).box(14)
 	self.add(header)

--- a/addons/loggie/tools/loggie_system_specs.gd
+++ b/addons/loggie/tools/loggie_system_specs.gd
@@ -21,8 +21,8 @@ func embed_specs() -> LoggieSystemSpecsMsg:
 func embed_essential_logger_specs() -> LoggieSystemSpecsMsg:
 	var loggie = get_logger()
 	self.add(loggie.msg("|\t Is in Production:").bold(), loggie.is_in_production()).nl()
-	self.add(loggie.msg("|\t Terminal Mode:").bold(), LoggieTools.TerminalMode.keys()[loggie.settings.terminal_mode]).nl()
-	self.add(loggie.msg("|\t Log Level:").bold(), LoggieTools.LogLevel.keys()[loggie.settings.log_level]).nl()
+	self.add(loggie.msg("|\t Terminal Mode:").bold(), LoggieEnums.TerminalMode.keys()[loggie.settings.terminal_mode]).nl()
+	self.add(loggie.msg("|\t Log Level:").bold(), LoggieEnums.LogLevel.keys()[loggie.settings.log_level]).nl()
 	return self
 
 ## Embeds advanced data about the logger into the content of this message.
@@ -38,11 +38,11 @@ func embed_advanced_logger_specs() -> LoggieSystemSpecsMsg:
 		
 		match setting_var_name:
 			"terminal_mode":
-				content_to_print = LoggieTools.TerminalMode.keys()[setting_value]
+				content_to_print = LoggieEnums.TerminalMode.keys()[setting_value]
 			"log_level":
-				content_to_print = LoggieTools.LogLevel.keys()[setting_value]
+				content_to_print = LoggieEnums.LogLevel.keys()[setting_value]
 			"box_characters_mode":
-				content_to_print = LoggieTools.BoxCharactersMode.keys()[setting_value]
+				content_to_print = LoggieEnums.BoxCharactersMode.keys()[setting_value]
 
 		self.add(loggie.msg("|\t", setting_var_name.capitalize(), ":").bold(), content_to_print).nl()
 	

--- a/addons/loggie/tools/loggie_system_specs.gd
+++ b/addons/loggie/tools/loggie_system_specs.gd
@@ -148,4 +148,3 @@ func embed_input_specs() -> LoggieSystemSpecsMsg:
 		self.add(loggie.msg("Virtual keyboard height:").bold(), DisplayServer.virtual_keyboard_get_height())
 
 	return self
-

--- a/addons/loggie/tools/loggie_system_specs.gd
+++ b/addons/loggie/tools/loggie_system_specs.gd
@@ -84,6 +84,7 @@ func embed_video_specs() -> LoggieSystemSpecsMsg:
 		self.add(loggie.msg("Adapter driver version:").bold(), video_adapter_driver_info[1]).nl()
 
 	return self
+
 ## Adds data about the display to the content of this message.
 func embed_display_specs() -> LoggieSystemSpecsMsg:
 	const screen_orientation_to_string = [

--- a/addons/loggie/tools/loggie_tools.gd
+++ b/addons/loggie/tools/loggie_tools.gd
@@ -116,7 +116,6 @@ static func rich_to_ANSI(text: String) -> String:
 	return text
 
 static func get_current_stack_frame_data() -> Dictionary:
-	var data = {}
 	var stack = get_stack()
 	const callerIndex = 3
 	var targetIndex = callerIndex if stack.size() >= callerIndex else stack.size() - 1
@@ -129,7 +128,6 @@ static func get_current_stack_frame_data() -> Dictionary:
 			"line" : 0,
 			"function" : "UnknownFunction"
 		}
-	return data
 
 ## Returns the `class_name` of a script.
 ## [br][param path_or_script] should be either an absolute path to the script 

--- a/addons/loggie/tools/loggie_tools.gd
+++ b/addons/loggie/tools/loggie_tools.gd
@@ -1,41 +1,6 @@
 @tool
 class_name LoggieTools extends Node
 
-## Based on which log level is currently set to be used by the Loggie., attempting to log a message that's on
-## a higher-than-configured log level will result in nothing happening.
-enum LogLevel {
-	ERROR, 	## Log level which includes only the logging of Error type messages.
-	WARN, 	## Log level which includes the logging of Error and Warning type messages.
-	NOTICE, ## Log level which includes the logging of Error, Warning and Notice type messages.
-	INFO,	## Log level which includes the logging of Error, Warning, Notice and Info type messages.
-	DEBUG	## Log level which includes the logging of Error, Warning, Notice, Info and Debug type messages.
-}
-
-enum TerminalMode {
-	PLAIN, ## Prints will be plain text.
-	ANSI,  ## Prints will be styled using the ANSI standard. Compatible with Powershell, Win CMD, etc.
-	BBCODE ## Prints will be styled using the Godot BBCode rules. Compatible with the Godot console.
-}
-
-enum BoxCharactersMode {
-	COMPATIBLE, ## Boxes are drawn using characters that compatible with any kind of terminal or text reader.
-	PRETTY ## Boxes are drawn using special unicode characters that create a prettier looking box which may not display properly in some terminals or text readers.
-}
-
-## Defines a list of possible approaches that can be taken to derive some kind of a class name proxy from a script that doesn't have a 'class_name' clause.
-enum NamelessClassExtensionNameProxy {
-	NOTHING, ## If there is no class_name, nothing will be displayed.
-	SCRIPT_NAME, ## Use the name of the script whose class_name we tried to read. (e.g. "my_script.gd").
-	BASE_TYPE, ## Use the name of the base type which the script extends (e.g. 'Node2D', 'Control', etc.)
-}
-
-## Defines a list of possible behaviors for the 'show_loggie_specs' setting.
-enum ShowLoggieSpecsMode {
-	DISABLED,
-	ESSENTIAL,
-	ADVANCED
-}
-
 ## Removes BBCode from the given text.
 static func remove_BBCode(text: String) -> String:
 	# The bbcode tags to remove.
@@ -142,7 +107,7 @@ static func get_current_stack_frame_data() -> Dictionary:
 ## (String, e.g. "res://my_script.gd"), or a [Script] object.
 ## [br][param proxy] defines which kind of text will be used as a replacement
 ## for the class name if the script has no 'class_name'.
-static func get_class_name_from_script(path_or_script : Variant, proxy : NamelessClassExtensionNameProxy) -> String:
+static func get_class_name_from_script(path_or_script : Variant, proxy : LoggieEnums.NamelessClassExtensionNameProxy) -> String:
 	var script
 	var _class_name = ""
 
@@ -175,9 +140,9 @@ static func get_class_name_from_script(path_or_script : Variant, proxy : Nameles
 			return get_class_name_from_script(base_script, proxy)
 		else:
 			match proxy:
-				LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE:
+				LoggieEnums.NamelessClassExtensionNameProxy.BASE_TYPE:
 					_class_name = script.get_instance_base_type()
-				LoggieTools.NamelessClassExtensionNameProxy.SCRIPT_NAME:
+				LoggieEnums.NamelessClassExtensionNameProxy.SCRIPT_NAME:
 					_class_name = script.get_script_property_list().front()["name"]
 
 	return _class_name
@@ -189,7 +154,7 @@ static func get_class_name_from_script(path_or_script : Variant, proxy : Nameles
 ## for the class name if the script has no 'class_name'.
 ## [br][br][b]Note:[/b] This is a compatibility method that will be used on older versions of Godot which
 ## don't support [method Script.get_global_name].
-static func extract_class_name_from_gd_script(path_or_script : Variant, proxy : NamelessClassExtensionNameProxy) -> String:
+static func extract_class_name_from_gd_script(path_or_script : Variant, proxy : LoggieEnums.NamelessClassExtensionNameProxy) -> String:
 	var path : String
 
 	if path_or_script is String:
@@ -220,9 +185,9 @@ static func extract_class_name_from_gd_script(path_or_script : Variant, proxy : 
 		var script = load(path)
 		if script is Script:
 			match proxy:
-				LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE:
+				LoggieEnums.NamelessClassExtensionNameProxy.BASE_TYPE:
 					_class_name = script.get_instance_base_type()
-				LoggieTools.NamelessClassExtensionNameProxy.SCRIPT_NAME:
+				LoggieEnums.NamelessClassExtensionNameProxy.SCRIPT_NAME:
 					_class_name = script.get_script_property_list().front()["name"]
 
 	file.close()

--- a/addons/loggie/tools/loggie_tools.gd
+++ b/addons/loggie/tools/loggie_tools.gd
@@ -29,6 +29,13 @@ enum NamelessClassExtensionNameProxy {
 	BASE_TYPE, ## Use the name of the base type which the script extends (e.g. 'Node2D', 'Control', etc.)
 }
 
+## Defines a list of possible behaviors for the 'show_loggie_specs' setting.
+enum ShowLoggieSpecsMode {
+	DISABLED,
+	ESSENTIAL,
+	ADVANCED
+}
+
 ## Removes BBCode from the given text.
 static func remove_BBCode(text: String) -> String:
 	# The bbcode tags to remove.
@@ -115,6 +122,7 @@ static func rich_to_ANSI(text: String) -> String:
 
 	return text
 
+## Returns a dictionary of call stack data related to the stack the call to this function is a part of.
 static func get_current_stack_frame_data() -> Dictionary:
 	var stack = get_stack()
 	const callerIndex = 3

--- a/addons/loggie/tools/loggie_tools.gd
+++ b/addons/loggie/tools/loggie_tools.gd
@@ -221,6 +221,18 @@ static func extract_class_name_from_gd_script(path_or_script : Variant, proxy : 
 
 	return _class_name
 
+## Prints out a bunch of useful data about a given script.
+## Useful for debugging.
+static func print_script_data(script : Script):
+	var msg = Loggie.msg("Script Data for:", script.get_path()).color("pink")
+	msg.add(":").nl()
+	msg.add(Loggie.msg("get_class():").color("slate_blue").bold()).add(script.get_class()).nl()
+	msg.add(Loggie.msg("get_global_name():").color("slate_blue").bold()).add(script.get_global_name()).nl()
+	msg.add(Loggie.msg("get_base_script():").color("slate_blue").bold()).add(script.get_base_script().resource_path if script.get_base_script() != null else "No base script.").nl()
+	msg.add(Loggie.msg("get_instance_base_type():").color("slate_blue").bold()).add(script.get_instance_base_type()).nl()
+	msg.add(Loggie.msg("get_script_property_list():").color("slate_blue").bold()).add(script.get_script_property_list()).nl()
+	msg.info()
+
 ## A dictionary of named colors matching the constants from [Color] used to help with rich text coloring.
 ## There may be a way to obtain these Color values without this dictionary if one can somehow check for the 
 ## existence and value of a constant on the Color class (since they're already there),

--- a/addons/loggie/tools/loggie_tools.gd
+++ b/addons/loggie/tools/loggie_tools.gd
@@ -147,6 +147,8 @@ static func get_class_name_from_script(path_or_script : Variant, proxy : Nameles
 	var _class_name = ""
 
 	if path_or_script is String or path_or_script is StringName:
+		if !ResourceLoader.exists(path_or_script, "Script"):
+			return _class_name
 		script = load(path_or_script)
 	elif path_or_script is Script:
 		script = path_or_script

--- a/addons/loggie/tools/loggie_tools.gd
+++ b/addons/loggie/tools/loggie_tools.gd
@@ -22,6 +22,13 @@ enum BoxCharactersMode {
 	PRETTY ## Boxes are drawn using special unicode characters that create a prettier looking box which may not display properly in some terminals or text readers.
 }
 
+## Defines a list of possible approaches that can be taken to derive some kind of a class name proxy from a script that doesn't have a 'class_name' clause.
+enum NamelessClassExtensionNameProxy {
+	NOTHING, ## If there is no class_name, nothing will be displayed.
+	SCRIPT_NAME, ## Use the name of the script whose class_name we tried to read. (e.g. "my_script.gd").
+	BASE_TYPE, ## Use the name of the base type which the script extends (e.g. 'Node2D', 'Control', etc.)
+}
+
 ## Removes BBCode from the given text.
 static func remove_BBCode(text: String) -> String:
 	# The bbcode tags to remove.
@@ -124,16 +131,72 @@ static func get_current_stack_frame_data() -> Dictionary:
 		}
 	return data
 
-## Opens a .gd script at the given path, reads the name of the class by checking
-## if it has a "class_name" clause and what comes after it, then caches that result in the
-## [member Loggie.class_names] dictionary.
-static func extract_class_name_from_gd_script(path) -> String:
+## Returns the `class_name` of a script.
+## [br][param path_or_script] should be either an absolute path to the script 
+## (String, e.g. "res://my_script.gd"), or a [Script] object.
+## [br][param proxy] defines which kind of text will be used as a replacement
+## for the class name if the script has no 'class_name'.
+static func get_class_name_from_script(path_or_script : Variant, proxy : NamelessClassExtensionNameProxy) -> String:
+	var script
+	var _class_name = ""
+
+	if path_or_script is String or path_or_script is StringName:
+		script = load(path_or_script)
+	elif path_or_script is Script:
+		script = path_or_script
+
+	if not (script is Script):
+		push_error("Invalid 'path_or_script' param provided to get_class_name_from_script: {path}".format({"path" : path_or_script}))
+	else:
+		if not script.has_method("get_global_name"):
+			# User is using a pre-4.3 version of Godot that doesn't have Script.get_global_name.
+			# We must use a different method to achieve this then.
+			return extract_class_name_from_gd_script(path_or_script, proxy)
+
+		# Try to get the class name directly.
+		_class_name = script.get_global_name()
+
+		if _class_name != "":
+			return _class_name
+
+		# If that's empty, the script is either a base class, or a class without a name.
+		# Check if this script has a base script, and if so, use that one as the target whose name to obtain.
+		# If it doesn't have it, use what the [param proxy] demands.
+		var base_script = script.get_base_script()
+		if base_script != null:
+			return get_class_name_from_script(base_script, proxy)
+		else:
+			match proxy:
+				LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE:
+					_class_name = script.get_instance_base_type()
+				LoggieTools.NamelessClassExtensionNameProxy.SCRIPT_NAME:
+					_class_name = script.get_script_property_list().front()["name"]
+
+	return _class_name
+
+## Opens and reads a .gd script file to find out its 'class_name' or what it 'extends'.
+## [param path_or_script] should be either an absolute path to the script 
+## (String, e.g. "res://my_script.gd"), or a [Script] object.
+## [br][param proxy] defines which kind of text will be used as a replacement
+## for the class name if the script has no 'class_name'.
+## [br][br][b]Note:[/b] This is a compatibility method that will be used on older versions of Godot which
+## don't support [method Script.get_global_name].
+static func extract_class_name_from_gd_script(path_or_script : Variant, proxy : NamelessClassExtensionNameProxy) -> String:
+	var path : String
+
+	if path_or_script is String:
+		path = path_or_script
+	elif path_or_script is Script:
+		path = path_or_script.resource_path
+	else:
+		push_error("Invalid 'path_or_script' param provided to extract_class_name_from_gd_script: {path}".format({"path" : path_or_script}))
+		return ""
+
 	var file = FileAccess.open(path, FileAccess.READ)
 	if not file:
 		return "File Open Error {filepath}".format({"filepath" : path})
 
 	var _class_name: String = ""
-	var extends_from: String = ""
 
 	for line_num in 40:  # Loop only up to 40 lines
 		if file.eof_reached():
@@ -141,15 +204,18 @@ static func extract_class_name_from_gd_script(path) -> String:
 
 		var line = file.get_line().strip_edges()
 
-		if line.begins_with("extends"):
-			extends_from = line.split(" ")[1]  # Get the base class if extends is found
-
 		if line.begins_with("class_name"):
-			_class_name = line.split(" ")[1]  # Get class name directly if defined
+			_class_name = line.split(" ")[1]
 			break
 
 	if _class_name == "":
-		_class_name = extends_from  # If class_name isn't defined, use the base class
+		var script = load(path)
+		if script is Script:
+			match proxy:
+				LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE:
+					_class_name = script.get_instance_base_type()
+				LoggieTools.NamelessClassExtensionNameProxy.SCRIPT_NAME:
+					_class_name = script.get_script_property_list().front()["name"]
 
 	file.close()
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -6,11 +6,24 @@ Loggie allows you to compose and style messages then send them to the output, wh
 Let's explore some of the features.
 
 # 📋 Table of Contents
+- [📚User Guide](#user-guide)
+- [📋 Table of Contents](#-table-of-contents)
 - [Log Files and Storage](#log-files-and-storage)
 - [Composing Messages](#composing-messages)
 	- [Creating a message](#creating-a-message)
 	- [Styling a message](#styling-a-message)
+				- [bold()](#bold)
+				- [italic()](#italic)
+				- [header()](#header)
+				- [color(color : String | Color)](#colorcolor--string--color)
+				- [box(h\_padding: int = 4)](#boxh_padding-int--4)
+				- [nl(amount: int = 1)](#nlamount-int--1)
+				- [hseparator(size: int = 16, alternative\_symbol: Variant = null)](#hseparatorsize-int--16-alternative_symbol-variant--null)
+				- [add(...)](#add)
+				- [prefix(prefix : String, separator : String = "")](#prefixprefix--string-separator--string--)
+				- [suffix(suffix : String, separator : String = "")](#suffixsuffix--string-separator--string--)
 	- [Outputting a message](#outputting-a-message)
+			- [Extras](#extras)
 - [Adjusting Message Formats](#adjusting-message-formats)
 - [Preprocessing](#preprocessing)
 	- [Eligibility Checks:](#eligibility-checks)
@@ -25,6 +38,9 @@ Let's explore some of the features.
 		- [Timestamps](#timestamps)
 - [Custom Settings](#custom-settings)
 - [Using a custom singleton name](#using-a-custom-singleton-name)
+			- [• Step 1:](#-step-1)
+			- [• Step 2:](#-step-2)
+			- [• Step 3:](#-step-3)
 - [Notable Technicalities](#notable-technicalities)
 
 ----------------------------------------
@@ -191,6 +207,16 @@ If Loggie is not configured to currently have that debug level enabled, the mess
 	Loggie.msg("Regular info message.").info()
 ```
 
+You can also use these Loggie shortcuts if you don't need to apply additional LoggieMsg modifiers:
+
+```gdscript
+	Loggie.error("Hello")
+	Loggie.info("Hello")
+	Loggie.notice("Hello")
+	Loggie.warn("Hello")
+	Loggie.debug("Hello")
+```
+
 #### Extras
 `warn()` and `error()` messages will only appear in the 'Debugger' tab of Godot, unless the 'Output Errors/Warning Also To Console' is turned on in Loggie Project Settings.
 
@@ -270,11 +296,15 @@ Based on what the target terminal is, the content of the message will be convert
 
 ### Class Name Derivation
 * Loggie can sniff out the script from which a call to Loggie was made, and by reading its `class_name` clause, figure out the name of the class that called it.
+* This feature performs better on Godot 4.3+ because it can use the `Script.get_global_name` method to get the class name without needing to read the file. If the old class extraction method is used, it may induce a small performance penalty if executed frequently on a variety of uncached classes in a short manner, since it performs a FileAccess read.
 * This name can then be included in the log if the setting for it is enabled:
 	* LoggieSettings.derive_and_show_class_names
 	* Loggie Project Settings -> Preprocessing -> Derive and Display Class Names
-* This process may induce a small performance penalty if executed frequently, since it performs a FileAccess read.
-* **Warning**: This only works if there is a debugger connected to the project while it's running, so it will only be useful during development most of the time. This is because this uses the `get_stack` function, whose documentation explains why it depends on the debugger. Therefore, class name derivation is automatically disabled in non-debug builds.
+* A setting allows you to specify what kind of substitute gets printed if a script does not have a `class_name`:
+	* LoggieSettings.nameless_class_name_proxy
+	* Loggie Project Settings -> Preprocessing -> Nameless Class Name Proxy
+
+**Warning**: This only works if there is a debugger connected to the project while it's running, so it will only be useful during development most of the time. This is because this uses the `get_stack` function, whose documentation explains why it depends on the debugger. Therefore, class name derivation is automatically disabled in non-debug builds.
 
 ----------------------------------------
 

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ config/description="Loggie is a basic logging utility for those who could use a 
 Loggie takes care that your logs always look clean in release builds, while allowing you to use extra styling for console targeted output. ANSI-compatible, and friendly both for solo developers and developers in a team (externally loaded settings for each developer).
 
 If you need something simple but effective, Loggie is your guy."
-config/version="1.1"
+config/version="1.2"
 run/main_scene="res://test/test.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://addons/loggie/assets/icon.png"

--- a/project.godot
+++ b/project.godot
@@ -27,6 +27,7 @@ config/icon="res://addons/loggie/assets/icon.png"
 [autoload]
 
 Loggie="*res://addons/loggie/loggie.gd"
+LoggieAutoloadedTalker="*res://test/testing_props/autoloads/LoggieAutoloadedTalker.gd"
 
 [editor_plugins]
 

--- a/test/LoggieTalker.gd
+++ b/test/LoggieTalker.gd
@@ -1,4 +1,0 @@
-class_name LoggieTalker extends Node
-
-func say(msg : String):
-	Loggie.msg(msg).info()

--- a/test/test.gd
+++ b/test/test.gd
@@ -7,23 +7,24 @@ class_name LoggieTestPlayground extends Control
 ## so that you can modify `Loggie.settings` on the fly during this script while having a backup of the original state.
 var original_settings : LoggieSettings
 
-const PATH_LOGGIE_TALKER = "res://test/testing_props/talkers/LoggieTalker.gd"
-const PATH_LOGGIE_TALKER_CHILD = "res://test/testing_props/talkers/LoggieTalkerChild.gd"
-const PATH_LOGGIE_TALKER_GRANDCHILD = "res://test/testing_props/talkers/LoggieTalkerGrandchild.gd"
-const PATH_LOGGIE_TALKER_NAMED_GRANDCHILD = "res://test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd"
-const PATH_LOGGIE_TALKER_NAMED_CHILD = "res://test/testing_props/talkers/LoggieTalkerNamedChild.gd"
+const SCRIPT_LOGGIE_TALKER = preload("res://test/testing_props/talkers/LoggieTalker.gd")
+const SCRIPT_LOGGIE_TALKER_CHILD = preload("res://test/testing_props/talkers/LoggieTalkerChild.gd")
+const SCRIPT_LOGGIE_TALKER_GRANDCHILD = preload("res://test/testing_props/talkers/LoggieTalkerGrandchild.gd")
+const SCRIPT_LOGGIE_TALKER_NAMED_GRANDCHILD = preload("res://test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd")
+const SCRIPT_LOGGIE_TALKER_NAMED_CHILD = preload("res://test/testing_props/talkers/LoggieTalkerNamedChild.gd")
 
 func _ready() -> void:
 	original_settings = Loggie.settings.duplicate()
 	setup_gui()
 
-	#print_setting_values_from_project_settings()
-	#print_actual_current_settings()
-	#print_talker_scripts_data()
-	#test_all_log_level_outputs()
-	#test_decors()
-	#test_output_from_classes_of_various_inheritances_and_origins()
-	#test_domains()
+	print_setting_values_from_project_settings()
+	print_actual_current_settings()
+	print_talker_scripts_data()
+	
+	test_all_log_level_outputs()
+	test_decors()
+	test_output_from_classes_of_various_inheritances_and_origins()
+	test_domains()
 
 func setup_gui():
 	$Label.text = "Loggie {version}".format({"version": Loggie.VERSION})
@@ -77,16 +78,16 @@ func test_output_from_classes_of_various_inheritances_and_origins():
 		talker.say_from_inner("This is an inner-class defined in that class.")
 
 		# Test how it looks when a script that has a `class_name` and extends LoggieTalker produces a log.
-		load(PATH_LOGGIE_TALKER_NAMED_CHILD).new().say("This is a named class that extends a named class and has its own implementation of a method.")
+		SCRIPT_LOGGIE_TALKER_NAMED_CHILD.new().say("This is a named class that extends a named class and has its own implementation of a method.")
 		
 		# Test how it looks when a script that has no `class_name` and extends LoggieTalker produces a log.
-		load(PATH_LOGGIE_TALKER_CHILD).new().say("This is an unnamed class that extends a named class and has its own implementation of a method'.")
+		SCRIPT_LOGGIE_TALKER_CHILD.new().say("This is an unnamed class that extends a named class and has its own implementation of a method'.")
 		
 		# Test how it looks when a script that has a `class_name` and extends a LoggieTalker extender produces a log.
-		load(PATH_LOGGIE_TALKER_NAMED_GRANDCHILD).new().say("This is a named class that extends a named class that extends a named class.")
+		SCRIPT_LOGGIE_TALKER_NAMED_GRANDCHILD.new().say("This is a named class that extends a named class that extends a named class.")
 		
 		# Test how it looks when a script that has no `class_name` and extends a LoggieTalker extender produces a log.
-		load(PATH_LOGGIE_TALKER_GRANDCHILD).new().say("This is an unnamed class that extends an unnamed class that extends a named class.")
+		SCRIPT_LOGGIE_TALKER_GRANDCHILD.new().say("This is an unnamed class that extends an unnamed class that extends a named class.")
 
 		print()
 	print()
@@ -138,15 +139,14 @@ func test_decors():
 
 ## Prints helpful data about some test-related scripts.
 func print_talker_scripts_data() -> void:
-	var paths = [
-		PATH_LOGGIE_TALKER, 
-		PATH_LOGGIE_TALKER_CHILD,
-		PATH_LOGGIE_TALKER_NAMED_CHILD, 
-		PATH_LOGGIE_TALKER_GRANDCHILD,
-		PATH_LOGGIE_TALKER_NAMED_GRANDCHILD
+	var scripts = [
+		SCRIPT_LOGGIE_TALKER, 
+		SCRIPT_LOGGIE_TALKER_CHILD,
+		SCRIPT_LOGGIE_TALKER_NAMED_CHILD, 
+		SCRIPT_LOGGIE_TALKER_GRANDCHILD,
+		SCRIPT_LOGGIE_TALKER_NAMED_GRANDCHILD
 	]
-	for path in paths:
-		var script : Script = load(path)
+	for script in scripts:
 		LoggieTools.print_script_data(script)
 
 ## Prints the values of all LoggieSettings settings obtained from Project Settings.

--- a/test/test.gd
+++ b/test/test.gd
@@ -56,13 +56,12 @@ func test_all_log_level_outputs():
 
 func test_output_from_classes_of_various_inheritances_and_origins():
 	Loggie.msg("Test Talkers").box(25).info()
-	Loggie.settings.derive_and_show_class_names = true
-	for proxy : LoggieTools.NamelessClassExtensionNameProxy in LoggieTools.NamelessClassExtensionNameProxy.values():
+	for proxy : LoggieEnums.NamelessClassExtensionNameProxy in LoggieEnums.NamelessClassExtensionNameProxy.values():
 		Loggie.class_names = {}
 		Loggie.settings.nameless_class_name_proxy = proxy
 		
 		Loggie.msg("Using proxy: {proxy}".format({
-			"proxy": LoggieTools.NamelessClassExtensionNameProxy.keys()[proxy]
+			"proxy": LoggieEnums.NamelessClassExtensionNameProxy.keys()[proxy]
 		})).header().info()
 		
 		LoggieAutoloadedTalker.say("This is an autoload class.")

--- a/test/test.gd
+++ b/test/test.gd
@@ -48,6 +48,13 @@ func test() -> void:
 	# If 'Loggie.settings.derive_and_show_class_names' is true, the name of the class should show up properly as prefix.
 	var talker = LoggieTalker.new()
 	talker.say("Greetings!")
+	
+	# Test shortcut wrappers.
+	Loggie.debug("Debug wrapper test.")
+	Loggie.info("Info wrapper test.")
+	Loggie.notice("Notice wrapper test.")
+	Loggie.warn("Warn wrapper test.")
+	Loggie.error("Error wrapper test.")
 
 func print_setting_values_from_project_settings():
 	for key in LoggieSettings.project_settings.keys():

--- a/test/test.gd
+++ b/test/test.gd
@@ -17,14 +17,14 @@ func _ready() -> void:
 	original_settings = Loggie.settings.duplicate()
 	setup_gui()
 
-	print_setting_values_from_project_settings()
-	print_actual_current_settings()
-	print_talker_scripts_data()
+	#print_setting_values_from_project_settings()
+	#print_actual_current_settings()
+	#print_talker_scripts_data()
 	
-	test_all_log_level_outputs()
-	test_decors()
-	test_output_from_classes_of_various_inheritances_and_origins()
-	test_domains()
+	#test_all_log_level_outputs()
+	#test_decors()
+	#test_output_from_classes_of_various_inheritances_and_origins()
+	#test_domains()
 
 func setup_gui():
 	$Label.text = "Loggie {version}".format({"version": Loggie.VERSION})
@@ -152,32 +152,21 @@ func print_talker_scripts_data() -> void:
 ## Prints the values of all LoggieSettings settings obtained from Project Settings.
 ## Deliberately uses [method print] instead of Loggie output methods.
 func print_setting_values_from_project_settings():
-	print(">> Loggie Settings (as read from Project Settings):")
+	Loggie.msg("Loggie Settings (as read from Project Settings):").header().info()
 	for key in LoggieSettings.project_settings.keys():
-		print("|\t{key} = {value}".format({
+		Loggie.msg("|\t{key} = {value}".format({
 			"key": key,
 			"value": ProjectSettings.get_setting(key)
-		}))
-	print("--------------------------------------------------\n")
+		})).info()
+	print()
 
 ## Prints the values of all LoggieSettings settings obtained directly from the current [Loggie] singleton's [member Loggie.settings].
 ## Deliberately uses [method print] instead of Loggie output methods.
 func print_actual_current_settings():
-	print(">> Loggie Settings (as read from Loggie.settings):")
-	var variables_to_print = [
-		"terminal_mode", "log_level", "show_loggie_specs", "show_system_specs",
-		"output_message_domain", "print_errors_to_console", "print_warnings_to_console",
-		"use_print_debug_for_debug_msg", "derive_and_show_class_names", "nameless_class_name_proxy",
-		"show_timestamps", "timestamps_use_utc", "format_header", "format_domain_prefix", "format_error_msg",
-		"format_warning_msg", "format_notice_msg", "format_info_msg", "format_debug_msg",
-		"h_separator_symbol", "box_characters_mode", "box_symbols_compatible", "box_symbols_pretty",
-	]
-	for var_name in variables_to_print:
-		print("|\t{varname} = {value}".format({
-			"varname": var_name,
-			"value": Loggie.settings.get(var_name)
-		}))
-	print("--------------------------------------------------\n")
+	Loggie.msg("Loggie Settings (as read from Loggie.settings):").header().info()
+	var settings_dict = Loggie.settings.to_dict()
+	Loggie.msg(settings_dict).info()
+	print()
 
 func reset_settings():
 	Loggie.settings = original_settings.duplicate()

--- a/test/test.gd
+++ b/test/test.gd
@@ -1,24 +1,117 @@
-extends Control
+## This script serves as a playground for testing out Loggie features.
+## It is not an actual test suite with assertions, but it can serve well 
+## for testing core functionality during development.
+class_name LoggieTestPlayground extends Control
+
+## Stores a duplicate of the [LoggieSettings] which are configured in [Loggie] in the moment this node becomes ready,
+## so that you can modify `Loggie.settings` on the fly during this script while having a backup of the original state.
+var original_settings : LoggieSettings
+
+const PATH_LOGGIE_TALKER = "res://test/testing_props/talkers/LoggieTalker.gd"
+const PATH_LOGGIE_TALKER_CHILD = "res://test/testing_props/talkers/LoggieTalkerChild.gd"
+const PATH_LOGGIE_TALKER_GRANDCHILD = "res://test/testing_props/talkers/LoggieTalkerGrandchild.gd"
+const PATH_LOGGIE_TALKER_NAMED_GRANDCHILD = "res://test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd"
+const PATH_LOGGIE_TALKER_NAMED_CHILD = "res://test/testing_props/talkers/LoggieTalkerNamedChild.gd"
 
 func _ready() -> void:
+	original_settings = Loggie.settings.duplicate()
+	setup_gui()
+
+	#print_setting_values_from_project_settings()
+	#print_actual_current_settings()
+	#print_talker_scripts_data()
+	#test_all_log_level_outputs()
+	#test_decors()
+	#test_output_from_classes_of_various_inheritances_and_origins()
+	#test_domains()
+
+func setup_gui():
 	$Label.text = "Loggie {version}".format({"version": Loggie.VERSION})
-	test()
+	print_rich("[i]Edit the test.tscn _ready function and uncomment the calls to features you want to test out.[/i]")
 
-func test() -> void:
-	# Test outputting a box header.
-	Loggie.msg("Box Header Test").color("red").box().info()
-	
-	# Test outputting a header, with a newline and a 30 character long horizontal separator.
-	Loggie.msg("Colored Header").header().color("yellow").nl().hseparator(30).info()
+# -----------------------------------------
+#region Tests
+# -----------------------------------------
 
+func test_all_log_level_outputs():
 	# Test all types of messages.
-	Loggie.msg("Hello World").info()
-	Loggie.msg("Hello", "World", "Multi", "Argument").info()
+	Loggie.msg("Test logging methods").box(25).info()
+	Loggie.msg("Test info").info()
+	Loggie.msg("Test", "info", "multi", "argument").info()
 	Loggie.msg("Test error.").error()
 	Loggie.msg("Test warning.").warn()
 	Loggie.msg("Test notice.").notice()
 	Loggie.msg("Test debug message.").debug()
-	
+	print()
+
+	# Test shortcut wrappers.
+	Loggie.msg("Test logging method wrappers").box(25).info()
+	Loggie.debug("Debug wrapper test.")
+	Loggie.info("Info wrapper test.")
+	Loggie.notice("Notice wrapper test.")
+	Loggie.warn("Warn wrapper test.")
+	Loggie.error("Error wrapper test.")
+	print()
+
+func test_output_from_classes_of_various_inheritances_and_origins():
+	Loggie.msg("Test Talkers").box(25).info()
+	Loggie.settings.derive_and_show_class_names = true
+	for proxy : LoggieTools.NamelessClassExtensionNameProxy in LoggieTools.NamelessClassExtensionNameProxy.values():
+		Loggie.class_names = {}
+		Loggie.settings.nameless_class_name_proxy = proxy
+		
+		Loggie.msg("Using proxy: {proxy}".format({
+			"proxy": LoggieTools.NamelessClassExtensionNameProxy.keys()[proxy]
+		})).header().info()
+		
+		LoggieAutoloadedTalker.say("This is an autoload class.")
+
+		# Test outputting a message from a different script.
+		# If 'Loggie.settings.derive_and_show_class_names' is true, the name of the class should show up properly as prefix -
+		# But the way it is represented also depends on the `Loggie.settings.nameless_class_name_proxy`, in case the
+		# class_name is empty.
+		var talker = LoggieTalker.new()
+		talker.say("This is a named class that extends a base type (Node).")
+		
+		# Test how it looks when code from an inner-class defined in LoggieTalker produces a log.
+		talker.say_from_inner("This is an inner-class defined in that class.")
+
+		# Test how it looks when a script that has a `class_name` and extends LoggieTalker produces a log.
+		load(PATH_LOGGIE_TALKER_NAMED_CHILD).new().say("This is a named class that extends a named class and has its own implementation of a method.")
+		
+		# Test how it looks when a script that has no `class_name` and extends LoggieTalker produces a log.
+		load(PATH_LOGGIE_TALKER_CHILD).new().say("This is an unnamed class that extends a named class and has its own implementation of a method'.")
+		
+		# Test how it looks when a script that has a `class_name` and extends a LoggieTalker extender produces a log.
+		load(PATH_LOGGIE_TALKER_NAMED_GRANDCHILD).new().say("This is a named class that extends a named class that extends a named class.")
+		
+		# Test how it looks when a script that has no `class_name` and extends a LoggieTalker extender produces a log.
+		load(PATH_LOGGIE_TALKER_GRANDCHILD).new().say("This is an unnamed class that extends an unnamed class that extends a named class.")
+
+		print()
+	print()
+	reset_settings()
+
+func test_domains():
+	Loggie.msg("Test Domains").box(25).info()
+	# Test outputting a message from an enabled custom domain.
+	Loggie.set_domain_enabled("Domain1", true)
+	Loggie.msg("> This message is coming from an enabled domain. (You should be seeing this)").domain("Domain1").info()
+
+	# Test outputting a message from a disabled domain.
+	Loggie.set_domain_enabled("Domain1", false)
+	Loggie.msg("Another similar message should appear below this notice if something is broken.").italic().color(Color.DIM_GRAY).notice()
+	Loggie.msg("> This message is coming from a disabled domain (You shouldn't be seeing this).").domain("Domain1").error()
+
+func test_decors():
+	Loggie.msg("Test Decorations").box(25).info()
+
+	# Test outputting a box header.
+	Loggie.msg("Box Header Test").color("red").box().info()
+
+	# Test outputting a header, with a newline and a 30 character long horizontal separator.
+	Loggie.msg("Colored Header").header().color("yellow").nl().hseparator(30).info()
+
 	# Test a supported color message.
 	Loggie.msg("I'm cyan.").color("cyan").info()
 	
@@ -35,51 +128,59 @@ func test() -> void:
 		"c" : ["A", {"B" : "2"}, 3]
 	}
 	Loggie.msg(testDict).info()
+	print()
 	
-	# Test outputting a message from an enabled custom domain.
-	Loggie.set_domain_enabled("Domain1", true)
-	Loggie.msg("This message is coming from an enabled domain.").domain("Domain1").info()
 
-	# Test outputting a message from a disabled domain.
-	Loggie.set_domain_enabled("Domain1", false)
-	Loggie.msg("This message is coming from a disabled domain (you shouldn't be seeing this in the output).").domain("Domain1").info()
+#endregion
+# -----------------------------------------
+#region Helpers
+# -----------------------------------------
 
-	# Test outputting a message from a different script.
-	# If 'Loggie.settings.derive_and_show_class_names' is true, the name of the class should show up properly as prefix.
-	var talker = LoggieTalker.new()
-	talker.say("Greetings!")
-	
-	# Test shortcut wrappers.
-	Loggie.debug("Debug wrapper test.")
-	Loggie.info("Info wrapper test.")
-	Loggie.notice("Notice wrapper test.")
-	Loggie.warn("Warn wrapper test.")
-	Loggie.error("Error wrapper test.")
+## Prints helpful data about some test-related scripts.
+func print_talker_scripts_data() -> void:
+	var paths = [
+		PATH_LOGGIE_TALKER, 
+		PATH_LOGGIE_TALKER_CHILD,
+		PATH_LOGGIE_TALKER_NAMED_CHILD, 
+		PATH_LOGGIE_TALKER_GRANDCHILD,
+		PATH_LOGGIE_TALKER_NAMED_GRANDCHILD
+	]
+	for path in paths:
+		var script : Script = load(path)
+		LoggieTools.print_script_data(script)
 
+## Prints the values of all LoggieSettings settings obtained from Project Settings.
+## Deliberately uses [method print] instead of Loggie output methods.
 func print_setting_values_from_project_settings():
+	print(">> Loggie Settings (as read from Project Settings):")
 	for key in LoggieSettings.project_settings.keys():
-		print(key, " -> ", ProjectSettings.get_setting(key))
+		print("|\t{key} = {value}".format({
+			"key": key,
+			"value": ProjectSettings.get_setting(key)
+		}))
+	print("--------------------------------------------------\n")
 
+## Prints the values of all LoggieSettings settings obtained directly from the current [Loggie] singleton's [member Loggie.settings].
+## Deliberately uses [method print] instead of Loggie output methods.
 func print_actual_current_settings():
-	print("terminal_mode => ", Loggie.settings.terminal_mode)
-	print("log_level => ", Loggie.settings.log_level)
-	print("show_loggie_specs => ", Loggie.settings.show_loggie_specs)
-	print("show_system_specs => ", Loggie.settings.show_system_specs)
-	print("output_message_domain => ", Loggie.settings.output_message_domain)
-	print("print_errors_to_console => ", Loggie.settings.print_errors_to_console)
-	print("print_warnings_to_console => ", Loggie.settings.print_warnings_to_console)
-	print("use_print_debug_for_debug_msg => ", Loggie.settings.use_print_debug_for_debug_msg)
-	print("derive_and_show_class_names => ", Loggie.settings.derive_and_show_class_names)
-	print("show_timestamps => ", Loggie.settings.show_timestamps)
-	print("timestamps_use_utc => ", Loggie.settings.timestamps_use_utc)
-	print("format_header => ", Loggie.settings.format_header)
-	print("format_domain_prefix => ", Loggie.settings.format_domain_prefix)
-	print("format_error_msg => ", Loggie.settings.format_error_msg)
-	print("format_warning_msg => ", Loggie.settings.format_warning_msg)
-	print("format_notice_msg => ", Loggie.settings.format_notice_msg)
-	print("format_info_msg => ", Loggie.settings.format_info_msg)
-	print("format_debug_msg => ", Loggie.settings.format_debug_msg)
-	print("h_separator_symbol => ", Loggie.settings.h_separator_symbol)
-	print("box_characters_mode => ", Loggie.settings.box_characters_mode)
-	print("box_symbols_compatible => ", Loggie.settings.box_symbols_compatible)
-	print("box_symbols_pretty => ", Loggie.settings.box_symbols_pretty)
+	print(">> Loggie Settings (as read from Loggie.settings):")
+	var variables_to_print = [
+		"terminal_mode", "log_level", "show_loggie_specs", "show_system_specs",
+		"output_message_domain", "print_errors_to_console", "print_warnings_to_console",
+		"use_print_debug_for_debug_msg", "derive_and_show_class_names", "nameless_class_name_proxy",
+		"show_timestamps", "timestamps_use_utc", "format_header", "format_domain_prefix", "format_error_msg",
+		"format_warning_msg", "format_notice_msg", "format_info_msg", "format_debug_msg",
+		"h_separator_symbol", "box_characters_mode", "box_symbols_compatible", "box_symbols_pretty",
+	]
+	for var_name in variables_to_print:
+		print("|\t{varname} = {value}".format({
+			"varname": var_name,
+			"value": Loggie.settings.get(var_name)
+		}))
+	print("--------------------------------------------------\n")
+
+func reset_settings():
+	Loggie.settings = original_settings.duplicate()
+	
+#endregion
+# -----------------------------------------

--- a/test/testing_props/autoloads/LoggieAutoloadedTalker.gd
+++ b/test/testing_props/autoloads/LoggieAutoloadedTalker.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func say(txt : String) -> LoggieMsg:
+	return Loggie.msg(txt).info()

--- a/test/testing_props/talkers/LoggieTalker.gd
+++ b/test/testing_props/talkers/LoggieTalker.gd
@@ -1,0 +1,16 @@
+## This class is an apparatus for testing the behavior of certain Loggie features.
+## It has no practical use beyond that.
+class_name LoggieTalker extends Node
+
+## Outputs an info message.
+func say(msg : String):
+	Loggie.msg(msg).info()
+
+## Outputs an info message from an [InnerLoggieTalker].
+func say_from_inner(msg : String):
+	InnerLoggieTalker.new().say(msg)
+
+## A helper class to test out the results of using Loggie from within an inner-class.
+class InnerLoggieTalker:
+	func say(msg : String):
+		Loggie.msg(msg).info()

--- a/test/testing_props/talkers/LoggieTalkerChild.gd
+++ b/test/testing_props/talkers/LoggieTalkerChild.gd
@@ -1,0 +1,7 @@
+# This script exists solely for the purposes of testing class name derivation features.
+extends LoggieTalker
+
+## Outputs an info message.
+func say(msg : String):
+	Loggie.msg(msg).info()
+	

--- a/test/testing_props/talkers/LoggieTalkerGrandchild.gd
+++ b/test/testing_props/talkers/LoggieTalkerGrandchild.gd
@@ -1,0 +1,5 @@
+# For the purposes of testing class name derivation features, 
+# this script is intentionally referring to its parent class with a
+# literal string path instead of a defined class_name,
+# nor does it define a class_name of its own.
+extends "res://test/testing_props/talkers/LoggieTalkerChild.gd"

--- a/test/testing_props/talkers/LoggieTalkerNamedChild.gd
+++ b/test/testing_props/talkers/LoggieTalkerNamedChild.gd
@@ -1,0 +1,6 @@
+# This script exists solely for the purposes of testing class name derivation features.
+class_name LoggieTalkerNamedChild extends LoggieTalker
+
+## Outputs an info message.
+func say(msg : String):
+	Loggie.msg(msg).info()

--- a/test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd
+++ b/test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd
@@ -1,0 +1,8 @@
+# For the purposes of testing class name derivation features, 
+# this script is intentionally referring to its parent class with a
+# literal string path instead of a defined class_name.
+class_name LoggieTalkerNamedGrandchild extends "res://test/testing_props/talkers/LoggieTalkerChild.gd"
+
+## Outputs an info message.
+func say(msg : String):
+	Loggie.msg(msg).info()

--- a/test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd
+++ b/test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd
@@ -1,7 +1,7 @@
 # For the purposes of testing class name derivation features, 
 # this script is intentionally referring to its parent class with a
 # literal string path instead of a defined class_name.
-class_name LoggieTalkerNamedGrandchild extends "res://test/testing_props/talkers/LoggieTalkerChild.gd"
+class_name LoggieTalkerNamedGrandchild extends "res://test/testing_props/talkers/LoggieTalkerNamedChild.gd"
 
 ## Outputs an info message.
 func say(msg : String):


### PR DESCRIPTION
### 🌟 Features
* **New Shortcuts:** You can now use `Loggie.error(...)`, `Loggie.info(...)`, `Loggie.notice(...)`, `Loggie.warn(...)` and `Loggie.debug(...)` wrappers to directly output at a log level. Useful for when you want to quickly output and don't care about applying additional LoggieMsg modifiers.

* **New Setting:** Nameless Class Name Proxy - allows users to specify what kind of substitute gets printed if 'Derive and Display Class Names From Scripts' is enabled, but a script doesn't have a 'class_name'.

* **New Signal:** `Loggie.log_attempted` - Emitted any time Loggie attempts to log a message, letting you know the result of the attempt and what the attempted message is. Useful for when you want to capture log data from Loggie for external use.

### 💪 Improvements
* Loggie can now be used while running only in editor (during `@tool` scripts, etc.) 
* The **Show Loggie Specs** setting has been updated to allow a selection between:
  * Don't show loggie specs
  * Show essential loggie specs
  * Show advanced (all) loggie specs
* The **Derive and Display Class Names** feature has been significantly changed, gaining on performance because it is no longer using FileAccess read to peek into scripts if your version of Godot supports the `Script.get_global_name` (4.3+ versions). It automatically detects whether it can use this optimization and does it if possible, still retaining the support for the previous approach for backwards compatibility. Loggie now also pre-reads the names of its own singleton and all autoload class names.

### ⚙️ Adjustments
* The **Show Loggie Specs** setting now also encompasses the Loggie boot message.
* When preprocessing a derived class name, LoggieMsg no longer prepends anything to the content if the class name is an empty string.

### 🐞 Bugfixes
* Fixed an issue where restarting Godot would cause Loggie settings to revert to defaults.
* Fixed an issue with retaining the configuration for the custom ProjectSettings generated by Loggie between multiple engine runs.
* Fix a wrong comparison that could've caused an error message to be printed unnecessarily.

### 🖥️ Developers
* Testing props are now stored in their own directory.
* Improved the state and structure of the testing script.
* Enums are now found in the LoggieEnums class.