### PR TITLE
v1.4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore

--- a/addons/loggie/custom_settings.gd.example
+++ b/addons/loggie/custom_settings.gd.example
@@ -17,16 +17,18 @@ func load():
 	self.use_print_debug_for_debug_msg = true
 	self.derive_and_show_class_names = true
 	self.nameless_class_name_proxy = LoggieEnums.NamelessClassExtensionNameProxy.BASE_TYPE
-	self.show_timestamps = true
+	self.output_timestamps = true
 	self.timestamps_use_utc = true
 
-	self.format_header = "[b][i]%s[/i][/b]"
-	self.format_domain_prefix = "[b](%s)[/b] %s"
-	self.format_error_msg = "[b][color=red][ERROR]:[/color][/b] %s"
-	self.format_warning_msg = "[b][color=orange][WARN]:[/color][/b] %s"
-	self.format_notice_msg = "[b][color=cyan][NOTICE]:[/color][/b] %s"
-	self.format_info_msg = "%s"
-	self.format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] %s"
+	self.format_timestamp = "[{day}.{month}.{year} {hour}:{minute}:{second}]"
+	self.format_info_msg = "{msg}"
+	self.format_notice_msg = "[b][color=cyan][NOTICE]:[/color][/b] {msg}"
+	self.format_warning_msg = "[b][color=orange][WARN]:[/color][/b] {msg}"
+	self.format_error_msg = "[b][color=red][ERROR]:[/color][/b] {msg}"
+	self.format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] {msg}"
+	self.format_header = "[b][i]{msg}[/i][/b]"
+	self.format_domain_prefix = "[b]({domain})[/b] {msg}"
+
 	self.h_separator_symbol = "-"
 	self.box_characters_mode = LoggieEnums.BoxCharactersMode.COMPATIBLE	
 

--- a/addons/loggie/custom_settings.gd.example
+++ b/addons/loggie/custom_settings.gd.example
@@ -7,16 +7,16 @@ func load():
 	# You could also have them loaded here in some custom way, for example, from a .json or .ini file.
 	# See the documentation of the [LoggieSettings] class to see all available options and their descriptions.
 	
-	self.terminal_mode = LoggieTools.TerminalMode.BBCODE
-	self.log_level = LoggieTools.LogLevel.INFO
-	self.show_loggie_specs = true
+	self.terminal_mode = LoggieEnums.TerminalMode.BBCODE
+	self.log_level = LoggieEnums.LogLevel.INFO
+	self.show_loggie_specs = LoggieEnums.ShowLoggieSpecsMode.ESSENTIAL
 	self.show_system_specs = true
 	self.output_message_domain = true
 	self.print_errors_to_console = true
 	self.print_warnings_to_console = true
 	self.use_print_debug_for_debug_msg = true
 	self.derive_and_show_class_names = true
-	self.nameless_class_name_proxy = LoggieTools.NamelessClassExtensionNameProxy.BASE_TYPE
+	self.nameless_class_name_proxy = LoggieEnums.NamelessClassExtensionNameProxy.BASE_TYPE
 	self.show_timestamps = true
 	self.timestamps_use_utc = true
 
@@ -28,7 +28,7 @@ func load():
 	self.format_info_msg = "%s"
 	self.format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] %s"
 	self.h_separator_symbol = "-"
-	self.box_characters_mode = LoggieTools.BoxCharactersMode.COMPATIBLE	
+	self.box_characters_mode = LoggieEnums.BoxCharactersMode.COMPATIBLE	
 
 	self.box_symbols_compatible = {
 		"top_left" : "-",

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -46,6 +46,7 @@ func _init() -> void:
 			self.settings.load()
 			if is_in_production():
 				self.settings.terminal_mode = LoggieEnums.TerminalMode.PLAIN
+				self.settings.box_characters_mode = LoggieEnums.BoxCharactersMode.COMPATIBLE
 		else:
 			push_error("Loggie loaded neither a custom nor a default settings file. This will break the plugin. Make sure that a valid loggie_settings.gd is in the same directory where loggie.gd is.")
 			return

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -6,7 +6,7 @@
 extends Node
 
 ## Stores a string describing the current version of Loggie.
-const VERSION : String = "v1.3"
+const VERSION : String = "v1.4"
 
 ## Emitted any time Loggie attempts to log a message.
 ## Useful for capturing the messages that pass through Loggie.

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -28,7 +28,7 @@ var domains : Dictionary = {}
 ## Holds a mapping between script paths and the names of the classes defined in those scripts.
 var class_names : Dictionary = {}
 
-func _ready() -> void:
+func _init() -> void:
 	var uses_original_settings_file = true
 	var default_settings_path = get_script().get_path().get_base_dir().path_join("loggie_settings.gd")
 	var custom_settings_path = get_script().get_path().get_base_dir().path_join("custom_settings.gd")

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -72,7 +72,7 @@ func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") ->
 	if self.preprocess:
 		# We append the name of the domain if that setting is enabled.
 		if !domain.is_empty() and loggie.settings.output_message_domain == true:
-			msg = loggie.settings.format_domain_prefix % [domain, msg]
+			msg = loggie.settings.format_domain_prefix.format({"domain" : domain, "msg" : msg})
 
 		# We prepend the name of the class that called the function which resulted in this output being generated
 		# (if Loggie settings are configured to do so).
@@ -94,9 +94,10 @@ func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") ->
 				})
 
 		# We prepend a timestamp to the message (if Loggie settings are configured to do so).
-		if loggie.settings.show_timestamps == true:
-			msg = "{timestamp} {msg}".format({
-				"timestamp" : Time.get_datetime_string_from_system(loggie.settings.timestamps_use_utc, true),
+		if loggie.settings.output_timestamps == true:
+			var format_dict : Dictionary = Time.get_datetime_dict_from_system(loggie.settings.timestamps_use_utc)
+			msg = "{formatted_time} {msg}".format({
+				"formatted_time" : loggie.settings.format_timestamp.format(format_dict),
 				"msg" : msg
 			})
 
@@ -123,7 +124,7 @@ func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") ->
 func error() -> LoggieMsg:
 	var loggie = get_logger()
 	if loggie != null and loggie.settings != null:
-		var msg = loggie.settings.format_error_msg % [self.content]
+		var msg = loggie.settings.format_error_msg.format({"msg": self.content})
 		output(LoggieEnums.LogLevel.ERROR, msg, self.domain_name)
 		if loggie.settings.print_errors_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.ERROR:
 			push_error(self.string())
@@ -134,7 +135,7 @@ func error() -> LoggieMsg:
 func warn() -> LoggieMsg:
 	var loggie = get_logger()
 	if loggie != null and loggie.settings != null:
-		var msg = loggie.settings.format_warning_msg % [self.content]
+		var msg = loggie.settings.format_warning_msg.format({"msg": self.content})
 		output(LoggieEnums.LogLevel.WARN, msg, self.domain_name)
 		if loggie.settings.print_warnings_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.WARN:
 			push_warning(self.string())
@@ -145,7 +146,7 @@ func warn() -> LoggieMsg:
 func notice() -> LoggieMsg:
 	var loggie = get_logger()
 	if loggie != null and loggie.settings != null:
-		var msg = loggie.settings.format_notice_msg % [self.content]
+		var msg = loggie.settings.format_notice_msg.format({"msg": self.content})
 		output(LoggieEnums.LogLevel.NOTICE, msg, self.domain_name)
 	return self
 
@@ -154,7 +155,7 @@ func notice() -> LoggieMsg:
 func info() -> LoggieMsg:
 	var loggie = get_logger()
 	if loggie != null and loggie.settings != null:
-		var msg = loggie.settings.format_info_msg % [self.content]
+		var msg = loggie.settings.format_info_msg.format({"msg": self.content})
 		output(LoggieEnums.LogLevel.INFO, msg, self.domain_name)
 	return self
 
@@ -163,7 +164,7 @@ func info() -> LoggieMsg:
 func debug() -> LoggieMsg:
 	var loggie = get_logger()
 	if loggie != null and loggie.settings != null:
-		var msg = loggie.settings.format_debug_msg % [self.content]
+		var msg = loggie.settings.format_debug_msg.format({"msg": self.content})
 		output(LoggieEnums.LogLevel.DEBUG, msg, self.domain_name)
 		if loggie.settings.use_print_debug_for_debug_msg and loggie.settings.log_level >= LoggieEnums.LogLevel.DEBUG:
 			print_debug(self.string())
@@ -214,7 +215,7 @@ func italic() -> LoggieMsg:
 ## Stylizes the current content of this message as a header.
 func header() -> LoggieMsg:
 	var loggie = get_logger()
-	self.content = loggie.settings.format_header % self.content
+	self.content = loggie.settings.format_header.format({"msg": self.content})
 	return self
 
 ## Constructs a decorative box with the given horizontal padding around the current content

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -306,7 +306,7 @@ func hseparator(size : int = 16, alternative_symbol : Variant = null) -> LoggieM
 ## Sets whether this message should be preprocessed and potentially modified with prefixes and suffixes during [method output].
 ## If turned off, while outputting this message, Loggie will skip the steps where it appends the messaage domain, class name, timestamp, etc.
 ## Whether preprocess is set to true doesn't affect the final conversion from RICH to ANSI or PLAIN, which always happens 
-## under some circumstances that based on other settings.
+## under some circumstances that are based on other settings.
 func preprocessed(shouldPreprocess : bool) -> LoggieMsg:
 	self.preprocess = shouldPreprocess
 	return self

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -199,17 +199,17 @@ func color(_color : Variant) -> LoggieMsg:
 	if _color is Color:
 		_color = _color.to_html()
 	
-	self.content = "[color=%s]%s[/color]" % [_color, self.content]
+	self.content = "[color={colorstr}]{msg}[/color]".format({"colorstr": _color, "msg": self.content})
 	return self
 
 ## Stylizes the current content of this message to be bold.
 func bold() -> LoggieMsg:
-	self.content = "[b]%s[/b]" % [self.content]
+	self.content = "[b]{msg}[/b]".format({"msg": self.content})
 	return self
 
 ## Stylizes the current content of this message to be italic.
 func italic() -> LoggieMsg:
-	self.content = "[i]%s[/i]" % [self.content]
+	self.content = "[i]{msg}[/i]".format({"msg": self.content})
 	return self
 
 ## Stylizes the current content of this message as a header.

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -122,46 +122,51 @@ func output(level : LoggieEnums.LogLevel, msg : String, domain : String = "") ->
 ## The [Loggie.settings.log_level] must be equal to or higher to the ERROR level for this to work.
 func error() -> LoggieMsg:
 	var loggie = get_logger()
-	var msg = loggie.settings.format_error_msg % [self.content]
-	output(LoggieEnums.LogLevel.ERROR, msg, self.domain_name)
-	if loggie.settings.print_errors_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.ERROR:
-		push_error(self.string())
+	if loggie != null and loggie.settings != null:
+		var msg = loggie.settings.format_error_msg % [self.content]
+		output(LoggieEnums.LogLevel.ERROR, msg, self.domain_name)
+		if loggie.settings.print_errors_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.ERROR:
+			push_error(self.string())
 	return self
 
 ## Outputs this message from Loggie as an Warning type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the WARN level for this to work.
 func warn() -> LoggieMsg:
 	var loggie = get_logger()
-	var msg = loggie.settings.format_warning_msg % [self.content]
-	output(LoggieEnums.LogLevel.WARN, msg, self.domain_name)
-	if loggie.settings.print_warnings_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.WARN:
-		push_warning(self.string())
+	if loggie != null and loggie.settings != null:
+		var msg = loggie.settings.format_warning_msg % [self.content]
+		output(LoggieEnums.LogLevel.WARN, msg, self.domain_name)
+		if loggie.settings.print_warnings_to_console and loggie.settings.log_level >= LoggieEnums.LogLevel.WARN:
+			push_warning(self.string())
 	return self
 
 ## Outputs this message from Loggie as an Notice type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the NOTICE level for this to work.
 func notice() -> LoggieMsg:
 	var loggie = get_logger()
-	var msg = loggie.settings.format_notice_msg % [self.content]
-	output(LoggieEnums.LogLevel.NOTICE, msg, self.domain_name)
+	if loggie != null and loggie.settings != null:
+		var msg = loggie.settings.format_notice_msg % [self.content]
+		output(LoggieEnums.LogLevel.NOTICE, msg, self.domain_name)
 	return self
 
 ## Outputs this message from Loggie as an Info type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the INFO level for this to work.
 func info() -> LoggieMsg:
 	var loggie = get_logger()
-	var msg = loggie.settings.format_info_msg % [self.content]
-	output(LoggieEnums.LogLevel.INFO, msg, self.domain_name)
+	if loggie != null and loggie.settings != null:
+		var msg = loggie.settings.format_info_msg % [self.content]
+		output(LoggieEnums.LogLevel.INFO, msg, self.domain_name)
 	return self
 
 ## Outputs this message from Loggie as a Debug type message.
 ## The [Loggie.settings.log_level] must be equal to or higher to the DEBUG level for this to work.
 func debug() -> LoggieMsg:
 	var loggie = get_logger()
-	var msg = loggie.settings.format_debug_msg % [self.content]
-	output(LoggieEnums.LogLevel.DEBUG, msg, self.domain_name)
-	if loggie.settings.use_print_debug_for_debug_msg and loggie.settings.log_level >= LoggieEnums.LogLevel.DEBUG:
-		print_debug(self.string())
+	if loggie != null and loggie.settings != null:
+		var msg = loggie.settings.format_debug_msg % [self.content]
+		output(LoggieEnums.LogLevel.DEBUG, msg, self.domain_name)
+		if loggie.settings.use_print_debug_for_debug_msg and loggie.settings.log_level >= LoggieEnums.LogLevel.DEBUG:
+			print_debug(self.string())
 	return self
 
 ## Returns the string content of this message.

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -20,6 +20,14 @@ static var loggie_singleton_name = "Loggie"
 ## relevant to Loggie, particularly important for the default way of loading [LoggieSettings] and
 ## setting up Godot Project Settings related to Loggie.
 const project_settings = {
+	"remove_settings_if_plugin_disabled" = {
+		"path": "loggie/general/remove_settings_if_plugin_disabled",
+		"default_value" : true,
+		"type" : TYPE_BOOL,
+		"hint" : PROPERTY_HINT_NONE,
+		"hint_string" : "",
+		"doc" : "Choose whether you want Loggie project settings to be wiped from ProjectSettings if the Loggie plugin is disabled.",
+	},
 	"terminal_mode" = {
 		"path": "loggie/general/terminal_mode",
 		"default_value" : LoggieEnums.TerminalMode.BBCODE,

--- a/addons/loggie/plugin.cfg
+++ b/addons/loggie/plugin.cfg
@@ -3,5 +3,5 @@
 name="Loggie"
 description="Simple functional stylish logger for your basic logging needs."
 author="Shiva Shadowsong"
-version="1.1"
+version="1.4"
 script="plugin.gd"

--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -39,13 +39,8 @@ func add_project_setting(setting_name: String, default_value : Variant, value_ty
 		ProjectSettings.set_setting(setting_name, default_value)
 		
 	ProjectSettings.set_initial_value(setting_name, default_value)
-	
-	ProjectSettings.add_property_info({
-		"name": setting_name,
-		"type": value_type,
-		"hint": type_hint,
-		"hint_string": hint_string
-	})
+	ProjectSettings.add_property_info({	"name": setting_name, "type": value_type, "hint": type_hint, "hint_string": hint_string})
+	ProjectSettings.set_as_basic(setting_name, true)
 
 	var error: int = ProjectSettings.save()
 	if error: 

--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -9,7 +9,12 @@ func _enable_plugin() -> void:
 	add_loggie_project_settings()
 
 func _disable_plugin() -> void:
-	remove_loggie_project_setings()
+	var wipe_setting_exists = ProjectSettings.has_setting(LoggieSettings.project_settings.remove_settings_if_plugin_disabled.path)
+	if (not wipe_setting_exists) or (wipe_setting_exists and ProjectSettings.get_setting(LoggieSettings.project_settings.remove_settings_if_plugin_disabled.path, true)):
+		push_warning("The Loggie plugin is being disabled, and all of its ProjectSettings are erased from Godot. If you wish to prevent this behavior, look for the 'Project Settings -> Loggie -> General -> Remove Settings if Plugin Disabled' option while the plugin is enabled.")
+		remove_loggie_project_setings()
+	else:
+		push_warning("The Loggie plugin is being disabled, but its ProjectSettings have been prevented from being removed from Godot. If you wish to allow that behavior, look for the 'Project Settings -> Loggie -> General -> Remove Settings if Plugin Disabled' option while the plugin is enabled.")
 	remove_autoload_singleton(LoggieSettings.loggie_singleton_name)
 
 ## Adds new Loggie related ProjectSettings to Godot.

--- a/addons/loggie/tools/loggie_system_specs.gd
+++ b/addons/loggie/tools/loggie_system_specs.gd
@@ -175,11 +175,11 @@ func embed_input_specs() -> LoggieSystemSpecsMsg:
 ## Useful for debugging.
 func embed_script_data(script : Script):
 	var loggie = get_logger()
-	var msg = loggie.msg("Script Data for:", script.get_path()).color("pink")
-	msg.add(":").nl()
-	msg.add(loggie.msg("get_class():").color("slate_blue").bold()).add(script.get_class()).nl()
-	msg.add(loggie.msg("get_global_name():").color("slate_blue").bold()).add(script.get_global_name()).nl()
-	msg.add(loggie.msg("get_base_script():").color("slate_blue").bold()).add(script.get_base_script().resource_path if script.get_base_script() != null else "No base script.").nl()
-	msg.add(loggie.msg("get_instance_base_type():").color("slate_blue").bold()).add(script.get_instance_base_type()).nl()
-	msg.add(loggie.msg("get_script_property_list():").color("slate_blue").bold()).add(script.get_script_property_list()).nl()
+	self.add("Script Data for:", script.get_path()).color("pink")
+	self.add(":").nl()
+	self.add(loggie.msg("get_class(): ").color("slate_blue").bold()).add(script.get_class()).nl()
+	self.add(loggie.msg("get_global_name(): ").color("slate_blue").bold()).add(script.get_global_name()).nl()
+	self.add(loggie.msg("get_base_script(): ").color("slate_blue").bold()).add(script.get_base_script().resource_path if script.get_base_script() != null else "No base script.").nl()
+	self.add(loggie.msg("get_instance_base_type(): ").color("slate_blue").bold()).add(script.get_instance_base_type()).nl()
+	self.add(loggie.msg("get_script_property_list(): ").color("slate_blue").bold()).add(script.get_script_property_list()).nl()
 	return self

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ config/description="Loggie is a basic logging utility for those who could use a 
 Loggie takes care that your logs always look clean in release builds, while allowing you to use extra styling for console targeted output. ANSI-compatible, and friendly both for solo developers and developers in a team (externally loaded settings for each developer).
 
 If you need something simple but effective, Loggie is your guy."
-config/version="1.3"
+config/version="1.4"
 run/main_scene="res://test/test.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://addons/loggie/assets/icon.png"

--- a/project.godot
+++ b/project.godot
@@ -32,3 +32,13 @@ LoggieAutoloadedTalker="*res://test/testing_props/autoloads/LoggieAutoloadedTalk
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/loggie/plugin.cfg")
+
+[loggie]
+
+general/remove_settings_if_plugin_disabled=false
+general/log_level=4
+general/show_loggie_specs=2
+timestamps/output_timestamps=true
+preprocessing/output_message_domain=true
+preprocessing/derive_and_display_class_names_from_scripts=true
+formats/box_characters_mode=1

--- a/test/test.gd
+++ b/test/test.gd
@@ -147,6 +147,7 @@ func print_talker_scripts_data() -> void:
 	]
 	for script in scripts:
 		var script_specs : LoggieSystemSpecsMsg = LoggieSystemSpecsMsg.new()
+		script_specs.use_logger(Loggie)
 		script_specs.embed_script_data(script).info()
 
 ## Prints the values of all LoggieSettings settings obtained from Project Settings.

--- a/test/test.gd
+++ b/test/test.gd
@@ -13,6 +13,9 @@ const SCRIPT_LOGGIE_TALKER_GRANDCHILD = preload("res://test/testing_props/talker
 const SCRIPT_LOGGIE_TALKER_NAMED_GRANDCHILD = preload("res://test/testing_props/talkers/LoggieTalkerNamedGrandchild.gd")
 const SCRIPT_LOGGIE_TALKER_NAMED_CHILD = preload("res://test/testing_props/talkers/LoggieTalkerNamedChild.gd")
 
+func _init() -> void:
+	Loggie.msg("Test message from test.gd _init.").warn()
+
 func _ready() -> void:
 	original_settings = Loggie.settings.duplicate()
 	setup_gui()

--- a/test/test.gd
+++ b/test/test.gd
@@ -146,7 +146,8 @@ func print_talker_scripts_data() -> void:
 		SCRIPT_LOGGIE_TALKER_NAMED_GRANDCHILD
 	]
 	for script in scripts:
-		LoggieTools.print_script_data(script)
+		var script_specs : LoggieSystemSpecsMsg = LoggieSystemSpecsMsg.new()
+		script_specs.embed_script_data(script).info()
 
 ## Prints the values of all LoggieSettings settings obtained from Project Settings.
 ## Deliberately uses [method print] instead of Loggie output methods.


### PR DESCRIPTION
### 🌟 Features
* **New Setting:** Remove Settings If Plugin Disabled - Allows users to specify whether their Loggie related ProjectSettings should be erased from Godot when the plugin gets disabled. 
> The erasure of these settings was a default behavior before, and it will remain so, unless this setting is explicitly turned on by the user. This feature is very useful during Loggie development, as well as during the process of patching loggie - as patches might require you to disable and re-enable the addon for some new features to get initialized, and it would be a shame to lose all your settings if you are configuring Loggie through ProjectSettings. Alternatively, look into using `custom_settings.gd`. More info about that [here](https://github.com/Shiva-Shadowsong/loggie/blob/main/docs/USER_GUIDE.md#custom-settings).

* **New Project Settings Category:** Formats.
It is now possible to modify the formatting of most message types _(including timestamps)_ and prefixes / suffixes via the ProjectSettings. The formatting method used everywhere is String.format which will also make these template formats easier to understand and modify.

![[feature screenshot](https://i.imgur.com/2J9lx2r.png)](https://i.imgur.com/2J9lx2r.png)

### 💪 Improvements

* When downloaded from the AssetLib, Loggie should no longer download any other files excepts the `addons/` directory in this repository.
* Loggie now automatically uses "Compatible" box characters in release builds.
* Loggie now initializes during `_init` instead of `_ready`, ensuring that it will be configured and available for use during the `_init` function of other scripts that are loading during similar time as Loggie. _(As before, Loggie should ideally be set as the first autoload in the Global/Autoloads order to prevent any other issues)._
* Explicitly set all Loggie ProjectSettings to be considered non-advanced settings in the ProjectSettings window.

### 🐞 Bugfixes
* Add an extra layer of safety to LoggieMsg output methods to protect against potential crashes if something goes wrong with `Loggie.settings`.
* Fixed LoggieSystemSpecs.embed_script_data not embedding content within the message that called it.

### 🖥️ Developers
* Fixed issues with the Test.gd `print_talker_scripts_data()` fn.
* Update the used Loggie project settings in Loggie Project to values which are friendlier for developers.
> Developers will usually be interested in having most of the loggie custom formats and outputs enabled, as well not have to worry about losing their settings when the plugin is disabled (since Loggie development calls for frequent disabling and re-enabling of the plugin).