### PR TITLE
New Feature: Stack Tracer

### DIFF
--- a/addons/loggie/custom_settings.gd.example
+++ b/addons/loggie/custom_settings.gd.example
@@ -18,6 +18,7 @@ func load():
 	self.print_errors_to_console = true
 	self.print_warnings_to_console = true
 	self.use_print_debug_for_debug_msg = true
+	self.use_print_stack_with_debug_msg = true
 	self.derive_and_show_class_names = true
 	self.nameless_class_name_proxy = LoggieEnums.NamelessClassExtensionNameProxy.BASE_TYPE
 	self.output_timestamps = true

--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -29,10 +29,6 @@ var class_names : Dictionary = {}
 ## [LoggieMsgChannel] objects those IDs are representing.
 var available_channels = {}
 
-## The default channel(s) messages outputted from ths logger will be sent to.
-## The value gets loaded in from [LoggieSettings] automatically.
-var default_channels = []
-
 ## Stores a reference to a [LoggieVersionManager] that will be used to manage the
 ## version of this instance.
 var version_manager : LoggieVersionManager = LoggieVersionManager.new()
@@ -60,11 +56,6 @@ func _init() -> void:
 		else:
 			push_error("Loggie loaded neither a custom nor a default settings file. This will break the plugin. Make sure that a valid loggie_settings.gd is in the same directory where loggie.gd is.")
 			return
-			
-	# Read the default channels from settings.
-	for channel_id in settings.default_channels:
-		if typeof(channel_id) == TYPE_STRING or typeof(channel_id) == TYPE_STRING_NAME:
-			default_channels.push_back(channel_id)
 
 	# Enforce certain settings if configured to do so.
 	if self.settings.enforce_optimal_settings_in_release_build == true and is_in_production():

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -60,7 +60,7 @@ func get_logger() -> Variant:
 ## settings. The given logger should be of class [Loggie] or an extension of it.
 func use_logger(logger_to_use : Variant) -> LoggieMsg:
 	self._logger = logger_to_use
-	self.used_channels = self._logger.default_channels
+	self.used_channels = self._logger.settings.default_channels
 	return self
 
 ## Sets the list of channels this message should be sent to when outputted.

--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -49,6 +49,9 @@ var custom_preprocess_flags : int = -1
 ## You need to call it at least once for this to have any results.
 var last_preprocess_result : String = ""
 
+## Whether this message should append the stack trace during preprocessing.
+var appends_stack : bool = false
+
 func _init(message = "", arg1 = null, arg2 = null, arg3 = null, arg4 = null, arg5 = null) -> void:
 	self.content[current_segment_index] = LoggieTools.concatenate_msg_and_args(message, arg1, arg2, arg3, arg4, arg5)
 
@@ -99,6 +102,9 @@ func get_preprocessed(flags : int, level : LoggieEnums.LogLevel) -> String:
 
 	if (flags & LoggieEnums.PreprocessStep.APPEND_TIMESTAMPS != 0):
 		message = _apply_format_timestamp(message)
+
+	if self.appends_stack or (loggie.settings.use_print_stack_with_debug_msg and level == LoggieEnums.LogLevel.DEBUG):
+		message = _apply_format_stack(message)
 
 	return message
 
@@ -236,6 +242,11 @@ func italic() -> LoggieMsg:
 func header() -> LoggieMsg:
 	var loggie = get_logger()
 	self.content[current_segment_index] = loggie.settings.format_header.format({"msg": self.content[current_segment_index]})
+	return self
+
+## Sets whether this message should append the stack trace during preprocessing.
+func stack(enabled : bool = true) -> LoggieMsg:
+	self.appends_stack = enabled
 	return self
 
 ## Constructs a decorative box with the given horizontal padding around the current segment
@@ -386,4 +397,11 @@ func _apply_format_timestamp(message : String) -> String:
 		"formatted_time" : loggie.settings.format_timestamp.format(format_dict),
 		"msg" : message
 	})
+	return message
+
+## Adds the stack trace to the given [param message] and returns the modified version of it.
+func _apply_format_stack(message : String) -> String:
+	var loggie = get_logger()
+	var stack_msg = loggie.stack()
+	message = message + stack_msg.string()
 	return message

--- a/test/test.gd
+++ b/test/test.gd
@@ -16,10 +16,6 @@ const SCRIPT_LOGGIE_TALKER_NAMED_CHILD = preload("res://test/testing_props/talke
 func _init() -> void:
 	Loggie.msg("Test message from test.gd _init.").warn()
 
-	var logpath : String = Loggie.get_script().resource_path
-	Loggie.info("Loggie path:", logpath, " -> dir:", logpath.get_base_dir())
-
-
 func _ready() -> void:
 	original_settings = Loggie.settings.duplicate()
 	setup_gui()
@@ -37,7 +33,6 @@ func _ready() -> void:
 	#test_discord_channel()
 	#test_slack_channel()
 	#test_update_widget()
-	
 
 func setup_gui():
 	$Label.text = "Loggie {version}".format({"version": Loggie.get("version_manager").version if Loggie.get("version_manager") != null else "<?>"})
@@ -93,7 +88,7 @@ func test_output_from_classes_of_various_inheritances_and_origins():
 		SCRIPT_LOGGIE_TALKER_NAMED_CHILD.new().say("This is a named class that extends a named class and has its own implementation of a method.")
 
 		# Test how it looks when a script that has no `class_name` and extends LoggieTalker produces a log.
-		SCRIPT_LOGGIE_TALKER_CHILD.new().say("This is an unnamed class that extends a named class and has its own implementation of a method'.")
+		SCRIPT_LOGGIE_TALKER_CHILD.new().say("This is an unnamed class that extends a named class and has its own implementation of a method.")
 
 		# Test how it looks when a script that has a `class_name` and extends a LoggieTalker extender produces a log.
 		SCRIPT_LOGGIE_TALKER_NAMED_GRANDCHILD.new().say("This is a named class that extends a named class that extends a named class.")


### PR DESCRIPTION
# Stack Tracer

Sometimes, it is desirable to see a stack trace showing where exactly the message came from.
Godot has a `print_stack` method that does this, but I've taken the time to integrate this type of printing into Loggie with more configurability and style.

You can now call `stack()` on any message to automatically append the stack trace at the end of that message **during the preprocessing step**.

```swift
Loggie.msg("Huh? Where did I come from?").stack().info()
```

Will result in something like this:

![https://i.imgur.com/RMc4aHG.png](https://i.imgur.com/RMc4aHG.png)

You can also:
* Specify the names of files which you want to omit from these stack traces if they were to appear there.
	* LoggieSettings.skipped_filenames_in_stack_trace
	* Project Settings -> Loggie -> General -> Skipped Filenames in Stack Trace
	
* Add the stack trace automatically to every `DEBUG` type message:
	* LoggieSettings.use_print_stack_with_debug_msg
	* Project Settings -> Loggie -> General -> Preprocessing -> Terminal -> Use Print Stack With Debug Msg