### PR TITLE
Add support for customizing the target channels of a domain.

### DIFF
--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -117,6 +117,7 @@ func output(level : LoggieEnums.LogLevel, msg_type : LoggieEnums.MsgType = Loggi
 	var loggie = get_logger()
 	var message = self.string()
 	var target_domain = self.domain_name
+	var target_channels = self.used_channels
 	
 	if loggie == null:
 		push_error("Attempt to log output with an invalid _logger. Make sure to call LoggieMsg.use_logger to set the appropriate logger before working with the message.")
@@ -137,7 +138,11 @@ func output(level : LoggieEnums.LogLevel, msg_type : LoggieEnums.MsgType = Loggi
 		return
 
 	# Send the message on all configured channels.
-	for channel_id : String in self.used_channels:
+	var custom_target_channels = loggie.get_domain_custom_target_channels(target_domain)
+	if custom_target_channels.size() > 0:
+		target_channels = custom_target_channels
+
+	for channel_id : String in target_channels:
 		var channel : LoggieMsgChannel = loggie.get_channel(channel_id)
 
 		if channel == null:


### PR DESCRIPTION
In case you'd like to configure messages coming from a specific domain to always get output on a custom channel(s), that is now possible via the new parameter in `set_domain_enabled`:

```swift
Loggie.set_domain_enabled(domain_name, is_enabled, custom_channels)
```