### PR TITLE
Custom String Conversion Method

### DIFF
--- a/addons/loggie/loggie.gd
+++ b/addons/loggie/loggie.gd
@@ -66,6 +66,9 @@ func _init() -> void:
 		self.settings.msg_format_mode = LoggieEnums.MsgFormatMode.PLAIN
 		self.settings.box_characters_mode = LoggieEnums.BoxCharactersMode.COMPATIBLE
 
+	# Set the default custom string converter.
+	self.settings.custom_string_converter = LoggieTools.convert_to_string
+
 	# Install all the built-in channels.
 	var terminal_channel : TerminalLoggieMsgChannel = load("res://addons/loggie/channels/terminal.gd").new()
 	terminal_channel.preprocess_flags = self.settings.preprocess_flags_terminal_channel

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -454,6 +454,14 @@ var box_symbols_pretty = {
 #endregion
 # ----------------------------------------------- #
 
+## A [Callable] function that takes 1 parameter [param something] (Variant),
+## and returns a [String] which represents the given [param something] in text.
+## By default, Loggie sets this to `LoggieTools.convert_to_string` when initialized.
+## [br][br]
+## You can, however, override that by changing this value to a valid replacement [Callable], 
+## after Loggie has initialized.
+var custom_string_converter : Callable
+
 ## Loads the initial (default) values for all of the LoggieSettings variables.
 ## (By default, loads them from ProjectSettings (if any modifications there exist), 
 ## or looks in [LoggieEditorPlugin..project_settings] for default values).


### PR DESCRIPTION
This PR makes it possible to override the default string conversion method Loggie uses.
It also improves the handling of 'null' type arguments.

Resolves #22 