### PR TITLE
[Fix] Move singleton creation/destruction to plugin enable/disable

### DIFF
--- a/addons/loggie/plugin.gd
+++ b/addons/loggie/plugin.gd
@@ -2,13 +2,13 @@
 class_name LoggieEditorPlugin extends EditorPlugin
 
 func _enter_tree():
-	add_autoload_singleton(LoggieSettings.loggie_singleton_name, "res://addons/loggie/loggie.gd")
 	add_loggie_project_settings()
 	Engine.set_meta("LoggieEditorPlugin", self)
 	if Engine.is_editor_hint():
 		Engine.set_meta("LoggieEditorInterfaceBaseControl", EditorInterface.get_base_control())
 	
 func _enable_plugin() -> void:
+	add_autoload_singleton(LoggieSettings.loggie_singleton_name, "res://addons/loggie/loggie.gd")
 	add_loggie_project_settings()
 
 func _disable_plugin() -> void:


### PR DESCRIPTION
[Fix] Move singleton creation/destruction to plugin enable/disable

Trying to load a singleton on `_enter_tree()` would make the editor think you need to save due to a singleton being added everytime the editor is launched. This resulted in that you always need to click `save` even without changing anything after starting the godot editor.

<img width="447" height="140" alt="image" src="https://github.com/user-attachments/assets/c6fbfad8-3538-402b-9d9c-0370b844a739" />


<br/><br/>
There are lot of discussion on this in other threads, Godot team officially updated their actual docs on this to use `_enable_plugin()`:
* https://github.com/godotengine/godot-docs/pull/9979

The side effect of this is that if user manually remove the autoload conf or disabled it, they would need to re-enable the plugin again to take effect. But anyway I dont remove the autoload any time soon.

Thanks.