### PR TITLE
Add Millisecond Timestamp and Engine Uptime Tracking

### DIFF
--- a/addons/loggie/loggie_message.gd
+++ b/addons/loggie/loggie_message.gd
@@ -415,10 +415,28 @@ func _apply_format_timestamp(message : String) -> String:
 	var format_dict : Dictionary = Time.get_datetime_dict_from_system(loggie.settings.timestamps_use_utc)
 	for field in ["month", "day", "hour", "minute", "second"]:
 		format_dict[field] = "%02d" % format_dict[field]
+
+	# Add the millisecond
+	var unix_time: float = Time.get_unix_time_from_system()
+	var millisecond: int = int((unix_time - int(unix_time)) * 1000.0)
+	format_dict["millisecond"] = "%03d" % millisecond
+	
+	# Add the startup time to the format dictionary.
+	var elapsed_millisecond: int = Time.get_ticks_msec()
+	var startup_hour: int = elapsed_millisecond / 3_600_000
+	var startup_minute: int = (elapsed_millisecond % 3_600_000) / 60_000
+	var startup_second: int = (elapsed_millisecond % 60_000) / 1000
+	var startup_millisecond: int = elapsed_millisecond % 1000
+	format_dict["startup_hour"] = "%02d" % startup_hour
+	format_dict["startup_minute"] = "%02d" % startup_minute
+	format_dict["startup_second"] = "%02d" % startup_second
+	format_dict["startup_millisecond"] = "%03d" % startup_millisecond
+
 	message = "{formatted_time} {msg}".format({
 		"formatted_time" : loggie.settings.format_timestamp.format(format_dict),
 		"msg" : message
 	})
+	
 	return message
 
 ## Adds the stack trace to the given [param message] and returns the modified version of it.

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -193,7 +193,7 @@ const project_settings = {
 	},
 	"format_timestamp" = {
 		"path": "loggie/formats/timestamp",
-		"default_value" : "[{day}.{month}.{year} {hour}:{minute}:{second}]",
+		"default_value" : "[{day}.{month}.{year} {hour}:{minute}:{second}:{millisecond}] [{startup_hour}:{startup_minute}:{startup_second}:{startup_millisecond}]",
 		"type" : TYPE_STRING,
 		"hint" : PROPERTY_HINT_NONE,
 		"hint_string" : "",
@@ -411,9 +411,10 @@ var format_info_msg = "{msg}"
 var format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] {msg}"
 
 ## The format used for timestamps when they are prepended to the output.[br]
-## The variables [param {day}], [param {month}], [param {year}], [param {hour}], [param {minute}], [param {second}], [param {weekday}], and [param {dst}] are supported.
+## The variables [param {day}], [param {month}], [param {year}], [param {hour}], [param {minute}], [param {second}], [param {millisecond}], [param {weekday}], [param {dst}],  are supported.
+## The variables [param {startup_hour}], [param {startup_minute}], [param {startup_second}], [param {startup_millisecond}] are also supported, and will be replaced with the time since the game started.
 ## You can customize this in your ProjectSettings, or custom_settings.gd (if using it).[br]
-var format_timestamp = "[{day}.{month}.{year} {hour}:{minute}:{second}]"
+var format_timestamp = "[{day}.{month}.{year} {hour}:{minute}:{second}:{millisecond}][{startup_hour}:{startup_minute}:{startup_second}:{startup_millisecond}]"
 
 ## The format used for each entry in a stack trace that is obtained through [method Loggie.stack].
 ## The variables [param {fn_name}], [param {index}], [param {source_path}], [param {line}] are supported.

--- a/addons/loggie/loggie_settings.gd
+++ b/addons/loggie/loggie_settings.gd
@@ -193,7 +193,7 @@ const project_settings = {
 	},
 	"format_timestamp" = {
 		"path": "loggie/formats/timestamp",
-		"default_value" : "[{day}.{month}.{year} {hour}:{minute}:{second}:{millisecond}] [{startup_hour}:{startup_minute}:{startup_second}:{startup_millisecond}]",
+		"default_value" : "[{day}.{month}.{year} {hour}:{minute}:{second}]",
 		"type" : TYPE_STRING,
 		"hint" : PROPERTY_HINT_NONE,
 		"hint_string" : "",
@@ -411,10 +411,9 @@ var format_info_msg = "{msg}"
 var format_debug_msg = "[b][color=pink][DEBUG]:[/color][/b] {msg}"
 
 ## The format used for timestamps when they are prepended to the output.[br]
-## The variables [param {day}], [param {month}], [param {year}], [param {hour}], [param {minute}], [param {second}], [param {millisecond}], [param {weekday}], [param {dst}],  are supported.
-## The variables [param {startup_hour}], [param {startup_minute}], [param {startup_second}], [param {startup_millisecond}] are also supported, and will be replaced with the time since the game started.
+## The variables [param {day}], [param {month}], [param {year}], [param {hour}], [param {minute}], [param {second}], [param {weekday}], and [param {dst}] are supported.
 ## You can customize this in your ProjectSettings, or custom_settings.gd (if using it).[br]
-var format_timestamp = "[{day}.{month}.{year} {hour}:{minute}:{second}:{millisecond}][{startup_hour}:{startup_minute}:{startup_second}:{startup_millisecond}]"
+var format_timestamp = "[{day}.{month}.{year} {hour}:{minute}:{second}]"
 
 ## The format used for each entry in a stack trace that is obtained through [method Loggie.stack].
 ## The variables [param {fn_name}], [param {index}], [param {source_path}], [param {line}] are supported.


### PR DESCRIPTION
Add Millisecond Timestamp and Engine Uptime Tracking
<img width="788" height="312" alt="image" src="https://github.com/user-attachments/assets/4d71622c-b470-426c-ae5c-d292411fc16b" />
